### PR TITLE
Name of server in lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 					"markdownDescription": "[InterSystems](https://www.intersystems.com)® servers that other extensions connect to. Each property of this object names a server and holds nested properties specifying how to connect to it. Server names may only contain characters 'A' to 'Z', 'a' to 'z', digits, '-', '.', '_' and '~' characters.",
 					"scope": "resource",
 					"default": {
-						"IRIS": {
+						"iris": {
 							"webServer": {
 								"scheme": "http",
 								"host": "127.0.0.1",
@@ -75,7 +75,7 @@
 							},
 							"description": "Connection to default local InterSystems IRIS™ installation. Delete if unwanted."
 						},
-						"CACHE": {
+						"cache": {
 							"webServer": {
 								"scheme": "http",
 								"host": "127.0.0.1",
@@ -83,7 +83,7 @@
 							},
 							"description": "Connection to default local InterSystems Caché® installation. Delete if unwanted."
 						},
-						"ENSEMBLE": {
+						"ensemble": {
 							"webServer": {
 								"scheme": "http",
 								"host": "127.0.0.1",
@@ -91,10 +91,10 @@
 							},
 							"description": "Connection to default local InterSystems Ensemble® installation. Delete if unwanted."
 						},
-						"/default": "IRIS"
+						"/default": "iris"
 					},
 					"patternProperties": {
-						"^[A-Za-z0-9-._~]+$": {
+						"^[a-z0-9-._~]+$": {
 							"type": "object",
 							"description": "A server definition, with properties that specify how to connect to it.",
 							"properties": {


### PR DESCRIPTION
Server's name, supposed to be used in URI of kind `isfs://servername`, standard URI supposed that Authority part is case-insensitive, while JSON keys are case-sensitive (VSCode settings). So, it would be better to have it as lowercase.