### PR TITLE
Support adding servers from quickpick

### DIFF
--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,0 +1,77 @@
+import * as vscode from "vscode";
+import { getServerNames } from "./getServerNames";
+
+export async function addServer(scope?: vscode.ConfigurationScope): Promise<string | undefined> {
+  const serverNames = getServerNames(scope);
+  const spec = { webServer: { scheme: "", host: "", port: 0 } };
+  return await vscode.window
+    .showInputBox({
+      placeHolder: "Name of new server definition",
+      validateInput: (value) => {
+        if (value === "") {
+          return "Required";
+        }
+        if (serverNames.filter((server) => server.name === value).length) {
+          return "Name already exists";
+        }
+        if (!value.match(/^[a-z0-9-._~]+$/)) {
+          return "Can only contain a-z, 0-9 and punctuation -._~";
+        }
+        return null;
+      },
+    })
+    .then(
+      async (name): Promise<string | undefined> => {
+        if (name) {
+          const host = await vscode.window.showInputBox({
+            placeHolder: "Hostname or IP address of web server",
+            validateInput: (value) => {
+              return value.length ? undefined : "Required";
+            },
+          });
+          if (host) {
+            spec.webServer.host = host;
+            const portString = await vscode.window.showInputBox({
+              placeHolder: "Port of web server",
+              validateInput: (value) => {
+                const port = +value;
+                return value.match(/\d+/) &&
+                  port.toString() === value &&
+                  port > 0 &&
+                  port < 65536
+                  ? undefined
+                  : "Required, 1-65535";
+              },
+            });
+            if (portString) {
+              spec.webServer.port = +portString;
+              const scheme = await vscode.window.showQuickPick(
+                ["http", "https"],
+                { placeHolder: "Type of connection" }
+              );
+              if (scheme) {
+                spec.webServer.scheme = scheme;
+                try {
+                  const config = vscode.workspace.getConfiguration(
+                    "intersystems",
+                    scope
+                  );
+                  // For simplicity we always add to the user-level (aka Global) settings
+                  const servers: any =
+                    config.inspect("servers")?.globalValue || {};
+                  servers[name] = spec;
+                  await config.update("servers", servers, true);
+                  return name;
+                } catch (error) {
+                  vscode.window.showErrorMessage(
+                    "Failed to store server definition"
+                  );
+                  return undefined;
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+}

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -47,7 +47,7 @@ export async function addServer(scope?: vscode.ConfigurationScope): Promise<stri
               spec.webServer.port = +portString;
               const scheme = await vscode.window.showQuickPick(
                 ["http", "https"],
-                { placeHolder: "Type of connection" }
+                { placeHolder: "Confirm connection type, then definition will be stored in your User Settings. 'Escape' to cancel.",  }
               );
               if (scheme) {
                 spec.webServer.scheme = scheme;

--- a/src/api/pickServer.ts
+++ b/src/api/pickServer.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { addServer } from './addServer';
 import { getServerNames } from './getServerNames';
 
 export async function pickServer(scope?: vscode.ConfigurationScope, options: vscode.QuickPickOptions = {}): Promise<string | undefined> {
@@ -13,7 +14,63 @@ export async function pickServer(scope?: vscode.ConfigurationScope, options: vsc
     names.forEach(element => {
         qpItems.push({label: element.name, description: element.description, detail: options?.matchOnDetail ? element.detail : undefined});
     });
-    return await vscode.window.showQuickPick(qpItems, options).then(item => {
-        return item ? item.label : undefined;
+
+    return await new Promise<string | undefined>((resolve, reject) => {
+        var result:string
+        var resolveOnHide = true;
+        const quickPick = vscode.window.createQuickPick();
+        quickPick.title = "Choose server or use '+' to add one" ;
+        quickPick.placeholder = options.placeHolder;
+        quickPick.matchOnDescription = options.matchOnDescription || true;
+        quickPick.matchOnDetail = options.matchOnDetail || false;
+        quickPick.items = qpItems;
+        const btnAdd: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('add'), tooltip: 'Define New Server' }
+        quickPick.buttons = [btnAdd];
+
+        async function addAndResolve() {
+            resolveOnHide = false;
+            // Add a new server
+            await addServer(scope)
+                .then((value) => {
+                    if (value) {
+                        // Resolve the pickServer quickpick promise and tidy it up
+                        resolve(value);
+                        quickPick.hide();
+                        quickPick.dispose();
+                    }
+                });
+        }
+
+        quickPick.onDidChangeSelection((items) => {
+            result = items[0].label;
+        });
+
+        quickPick.onDidChangeValue(value => {
+            if (value === '+') {
+                addAndResolve();
+            }
+        })
+
+        quickPick.onDidTriggerButton((button) => {
+            if (button === btnAdd) {
+                addAndResolve();
+            }
+        });
+
+        quickPick.onDidAccept(() => {
+            resolve(result);
+            quickPick.hide();
+            quickPick.dispose();
+        });
+
+        quickPick.onDidHide(() => {
+            // flag used by addAndResolve to prevent resolve here
+            if (resolveOnHide) {
+                resolve(undefined);
+            }
+            quickPick.dispose();
+        });
+        
+        quickPick.show();
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,18 +14,18 @@ export interface ServerName {
 }
 
 export interface WebServerSpec {
-    scheme: string,
+    scheme?: string,
     host: string,
     port: number,
-    pathPrefix: string
+    pathPrefix?: string
 }
 
 export interface ServerSpec {
     name: string,
     webServer: WebServerSpec,
-    username: string,
-    password: string,
-    description: string
+    username?: string,
+    password?: string,
+    description?: string
 }
 
 export function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
This PR implements #23

![image](https://user-images.githubusercontent.com/6726799/92894606-a56a0980-f412-11ea-9aa3-42caee1cbb6e.png)

To begin, click the "+" button, or type the '+' character.

You will be prompted for connection name, host, port and scheme (http/https). Definition goes into user-level settings.json.

