### PR TITLE
fix #30 rename the three built-in (default) connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
           "markdownDescription": "[InterSystems](https://www.intersystems.com)® servers that other extensions connect to. Each property of this object names a server and holds nested properties specifying how to connect to it. Server names may only contain characters 'A' to 'Z', 'a' to 'z', digits, '-', '.', '_' and '~' characters.",
           "scope": "resource",
           "default": {
-            "iris": {
+            "default~iris": {
               "webServer": {
                 "scheme": "http",
                 "host": "127.0.0.1",
@@ -80,7 +80,7 @@
               },
               "description": "Connection to local InterSystems IRIS™ installed with default settings."
             },
-            "cache": {
+            "default~cache": {
               "webServer": {
                 "scheme": "http",
                 "host": "127.0.0.1",
@@ -88,7 +88,7 @@
               },
               "description": "Connection to local InterSystems Caché® installed with default settings."
             },
-            "ensemble": {
+            "default~ensemble": {
               "webServer": {
                 "scheme": "http",
                 "host": "127.0.0.1",
@@ -96,7 +96,7 @@
               },
               "description": "Connection to local InterSystems Ensemble® installed with default settings."
             },
-            "/default": "iris"
+            "/default": "default~iris"
           },
           "patternProperties": {
             "^[a-z0-9-._~]+$": {

--- a/src/api/getServerNames.ts
+++ b/src/api/getServerNames.ts
@@ -3,6 +3,7 @@ import { ServerName, ServerSpec } from '../extension';
 
 export function getServerNames(scope?: vscode.ConfigurationScope): ServerName[] {
     let names: ServerName[] = [];
+    let defaultNames: ServerName[] = [];
     const servers = vscode.workspace.getConfiguration('intersystems', scope).get('servers');
 
     if (typeof servers === 'object' && servers) {
@@ -16,14 +17,27 @@ export function getServerNames(scope?: vscode.ConfigurationScope): ServerName[] 
         }
         for (const key in servers) {
             if (!key.startsWith('/') && key !== defaultName) {
-                names.push({
-                    name: key,
-                    description: servers[key].description || '',
-                    detail: serverDetail(servers[key])
-                });
+                const inspected = vscode.workspace.getConfiguration('intersystems.servers', scope).inspect(key);
+
+                // At least in VS Code 1.49 the defaultValue unexpectedly returns undefined
+                // even for keys that are defined in package.json as defaults. So we have to check negatively all the other possibilities.
+                if (!inspected?.globalLanguageValue && !inspected?.globalValue && !inspected?.workspaceFolderLanguageValue && !inspected?.workspaceFolderValue && !inspected?.workspaceLanguageValue && !inspected?.workspaceValue) {
+                    defaultNames.push({
+                        name: key,
+                        description: servers[key].description || '',
+                        detail: serverDetail(servers[key])
+                    });
+                } else {
+                    names.push({
+                        name: key,
+                        description: servers[key].description || '',
+                        detail: serverDetail(servers[key])
+                    });
+                }
             }
         }
     }
+    names.push(...defaultNames);
     return names;
 }
 


### PR DESCRIPTION
This PR fixes #30

They are now `default~iris`, `default~cache` and `default~ensemble`. Previously: `iris`, `cache` and `ensemble`

Also push them to the bottom of the list.
