### PR TITLE
fix #41 make pickServer API respect ignoreFocusOut option if passed

### DIFF
--- a/src/api/pickServer.ts
+++ b/src/api/pickServer.ts
@@ -23,6 +23,7 @@ export async function pickServer(scope?: vscode.ConfigurationScope, options: vsc
         quickPick.placeholder = options.placeHolder;
         quickPick.matchOnDescription = options.matchOnDescription || true;
         quickPick.matchOnDetail = options.matchOnDetail || false;
+        quickPick.ignoreFocusOut = options.ignoreFocusOut || false;
         quickPick.items = qpItems;
         const btnAdd: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('add'), tooltip: 'Define New Server' }
         quickPick.buttons = [btnAdd];


### PR DESCRIPTION
This PR fixes #41

https://github.com/intersystems-community/vscode-objectscript/pull/390 makes use of this to keep the server list visible if focus is moved away when on the first quickpick during adding a server namespace to the workspace.