### PR TITLE
fix #64 Add '/hideEmbeddedEntries' boolean to 'intersystems.servers'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1323,9 +1323,9 @@
 			}
 		},
 		"ovsx": {
-			"version": "0.1.0-next.72b2e9d",
-			"resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.1.0-next.72b2e9d.tgz",
-			"integrity": "sha512-bjuJt+LOZgPDNRzMsAn6CkS65HHsKxQM2t7CbssSdLNopVCHJR8enWljsvvt/6+DwRN1BrhTIbMrfhKNBY6+Rw==",
+			"version": "0.1.0-next.ae88c6d",
+			"resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.1.0-next.ae88c6d.tgz",
+			"integrity": "sha512-1CeRrtSiQQ15MiQFhmgHkvH0o8zVzAZ5SjZFQWGq4EeEShcUKWOjkNe0/ecAX6DAHpSOtVirM0VT79Oej8kH4Q==",
 			"dev": true,
 			"requires": {
 				"commander": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,11 @@
           "properties": {
             "/default": {
               "type": "string",
-              "description": "Name of the default server."
+              "description": "Name of the server to promote to the top of pick lists."
+            },
+            "/hideEmbeddedEntries": {
+              "type": "boolean",
+              "description": "Do not append the built-in 'default~*' server definitions to pick lists."
             }
           },
           "additionalProperties": false

--- a/src/api/getServerNames.ts
+++ b/src/api/getServerNames.ts
@@ -37,7 +37,9 @@ export function getServerNames(scope?: vscode.ConfigurationScope): ServerName[] 
             }
         }
     }
-    names.push(...defaultNames);
+    if (!vscode.workspace.getConfiguration('intersystems.servers', scope).get('/hideEmbeddedEntries')) {
+        names.push(...defaultNames);
+    }
     return names;
 }
 

--- a/src/api/getServerNames.ts
+++ b/src/api/getServerNames.ts
@@ -7,7 +7,15 @@ export function getServerNames(scope?: vscode.ConfigurationScope): ServerName[] 
     const servers = vscode.workspace.getConfiguration('intersystems', scope).get('servers');
 
     if (typeof servers === 'object' && servers) {
-        const myDefault: string = vscode.workspace.getConfiguration('intersystems.servers', scope).inspect('/default')?.defaultValue ? '' : servers['/default'] || '';
+        
+        // Helper function to return true iff inspected setting is not explicitly set at any level
+        const notSet = (inspected):boolean => {
+            return !inspected?.globalLanguageValue && !inspected?.globalValue && !inspected?.workspaceFolderLanguageValue && !inspected?.workspaceFolderValue && !inspected?.workspaceLanguageValue && !inspected?.workspaceValue;
+        }
+        
+        // If a valid default has been explicitly nominated, add it first
+        const inspectedDefault = vscode.workspace.getConfiguration('intersystems.servers', scope).inspect('/default');
+        const myDefault: string = notSet(inspectedDefault) ? '' : servers['/default'] || '';
         if (myDefault.length > 0 && servers[myDefault]) {
             names.push({
                 name: myDefault,
@@ -15,13 +23,14 @@ export function getServerNames(scope?: vscode.ConfigurationScope): ServerName[] 
                 detail: serverDetail(servers[myDefault])
             });
         }
+ 
+        // Process the rest
         for (const key in servers) {
             if (!key.startsWith('/') && key !== myDefault) {
                 const inspected = vscode.workspace.getConfiguration('intersystems.servers', scope).inspect(key);
 
-                // At least in VS Code 1.49 the defaultValue unexpectedly returns undefined
-                // even for keys that are defined in package.json as defaults. So we have to check negatively all the other possibilities.
-                if (!inspected?.globalLanguageValue && !inspected?.globalValue && !inspected?.workspaceFolderLanguageValue && !inspected?.workspaceFolderValue && !inspected?.workspaceLanguageValue && !inspected?.workspaceValue) {
+                // Collect embedded (default~*) servers separately
+                if (notSet(inspected)) {
                     defaultNames.push({
                         name: key,
                         description: servers[key].description || '',
@@ -37,6 +46,8 @@ export function getServerNames(scope?: vscode.ConfigurationScope): ServerName[] 
             }
         }
     }
+
+    // Append the embedded servers unless suppressed
     if (!vscode.workspace.getConfiguration('intersystems.servers', scope).get('/hideEmbeddedEntries')) {
         names.push(...defaultNames);
     }


### PR DESCRIPTION
This PR fixes #64 by implementing a new `/hideEmbeddedEntries` setting.

Example of usage:

```
	"intersystems.servers": {
		"/hideEmbeddedEntries": true,
		"dem-dev": {
			"description": "DEV on DEM",
			"webServer": {
				"host": "dem",
				"port": 52774
			},
			"username": "me"
		}
	}

```