### PR TITLE
'Alt' commands on the Edit and View buttons, for accessing web application files

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,6 +314,16 @@
         "command": "intersystems-community.servermanager.viewNamespace",
         "title": "View Code in Namespace",
         "icon": "$(eye)"
+      },
+      {
+        "command": "intersystems-community.servermanager.editNamespaceWebAppFiles",
+        "title": "Edit Web Application Files for Namespace",
+        "icon": "$(file-code)"
+      },
+      {
+        "command": "intersystems-community.servermanager.viewNamespaceWebAppFiles",
+        "title": "View Web Application Files for Namespace",
+        "icon": "$(telescope)"
       }
     ],
     "submenus": [
@@ -373,6 +383,54 @@
         {
           "command": "intersystems-community.servermanager.openPortalTab",
           "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.retryServer",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.setIconRed",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.setIconOrange",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.setIconYellow",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.setIconGreen",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.setIconBlue",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.setIconPurple",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.resetIconColor",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.editNamespace",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.viewNamespace",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.editNamespaceWebAppFiles",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.viewNamespaceWebAppFiles",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -420,11 +478,13 @@
         },
         {
           "command": "intersystems-community.servermanager.editNamespace",
+          "alt": "intersystems-community.servermanager.editNamespaceWebAppFiles",
           "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
           "group": "inline@10"
         },
         {
           "command": "intersystems-community.servermanager.viewNamespace",
+          "alt": "intersystems-community.servermanager.viewNamespaceWebAppFiles",
           "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
           "group": "inline@20"
         },

--- a/package.json
+++ b/package.json
@@ -317,12 +317,12 @@
       },
       {
         "command": "intersystems-community.servermanager.editNamespaceWebAppFiles",
-        "title": "Edit Web Application Files for Namespace",
+        "title": "Edit Web Application Files",
         "icon": "$(file-code)"
       },
       {
         "command": "intersystems-community.servermanager.viewNamespaceWebAppFiles",
-        "title": "View Web Application Files for Namespace",
+        "title": "View Web Application Files",
         "icon": "$(telescope)"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,7 +202,7 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
-    const addWorkspaceFolderAsync = async (readonly: boolean, namespaceTreeItem?: ServerTreeItem) => {
+    const addWorkspaceFolderAsync = async (readonly: boolean, csp: boolean, namespaceTreeItem?: ServerTreeItem) => {
         if (namespaceTreeItem) {
             const pathParts = namespaceTreeItem.id?.split(':');
             if (pathParts && pathParts.length === 4) {
@@ -210,8 +210,8 @@ export function activate(context: vscode.ExtensionContext) {
                 const namespace = pathParts[3];
                 const serverSpec = await getServerSpec(serverName, undefined, undefined, true);
                 if (serverSpec) {
-                    const uri = vscode.Uri.parse(`isfs${readonly ? "-readonly" : ""}://${serverName}:${namespace}/${serverSpec.webServer.pathPrefix || ''}`);
-                    const label = `${serverName}:${namespace}${readonly ? " (read-only)" : ""}`;
+                    const uri = vscode.Uri.parse(`isfs${readonly ? "-readonly" : ""}://${serverName}:${namespace}/${serverSpec.webServer.pathPrefix || ''}${csp ? '?csp' : ''}`);
+                    const label = `${serverName}:${namespace}${csp ? ' webfiles' : ''}${readonly ? " (read-only)" : ""}`;
                     const added = vscode.workspace.updateWorkspaceFolders(
                         vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.length : 0,
                         0,
@@ -232,11 +232,19 @@ export function activate(context: vscode.ExtensionContext) {
     }
     
     context.subscriptions.push(
-        vscode.commands.registerCommand(`${extensionId}.editNamespace`, async (namespaceTreeItem?: ServerTreeItem) => {await addWorkspaceFolderAsync(false, namespaceTreeItem)})
+        vscode.commands.registerCommand(`${extensionId}.editNamespace`, async (namespaceTreeItem?: ServerTreeItem) => {await addWorkspaceFolderAsync(false, false, namespaceTreeItem)})
     );
     
     context.subscriptions.push(
-        vscode.commands.registerCommand(`${extensionId}.viewNamespace`, async (namespaceTreeItem?: ServerTreeItem) => {await addWorkspaceFolderAsync(true, namespaceTreeItem)})
+        vscode.commands.registerCommand(`${extensionId}.viewNamespace`, async (namespaceTreeItem?: ServerTreeItem) => {await addWorkspaceFolderAsync(true, false, namespaceTreeItem)})
+    );
+    
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${extensionId}.editNamespaceWebAppFiles`, async (namespaceTreeItem?: ServerTreeItem) => {await addWorkspaceFolderAsync(false, true, namespaceTreeItem)})
+    );
+    
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${extensionId}.viewNamespaceWebAppFiles`, async (namespaceTreeItem?: ServerTreeItem) => {await addWorkspaceFolderAsync(true, true, namespaceTreeItem)})
     );
 
     // Listen for relevant configuration changes


### PR DESCRIPTION
This PR implements 'Alt' alternative commands to the Edit and View buttons to add the `?csp` queryparam to isfs folder being added to the workspace.

