### PR TITLE
fix #92 Allow extension in untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
   "categories": [
     "Other"
   ],
+  "capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
   "contributors": [
     {
       "name": "John Murray",


### PR DESCRIPTION
This PR fixes #92

To test, install the VSIX into 1.57 (currently only available as Insiders, but likely to ship as Stable any day now). Make sure that the extension can be enabled even though a workspace is untrusted:

Before:
![image](https://user-images.githubusercontent.com/6726799/121310186-01f34a00-c8fb-11eb-8054-b5145c581844.png)

After:
![image](https://user-images.githubusercontent.com/6726799/121310385-3a932380-c8fb-11eb-9ef9-891d5312d6ac.png)
