### PR TITLE
bump vsce and ovsx devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "@types/node": "^8.10.60",
     "glob": "^7.1.6",
     "mocha": "^8.3.2",
-    "ovsx": "latest",
+    "ovsx": "^0.2.1",
     "ts-loader": "^6.2.2",
     "tslint": "^5.20.1",
     "typescript": "^3.8.3",
-    "vsce": "^1.75.0",
+    "vsce": "^1.99.0",
     "vscode-test": "^1.3.0"
   },
   "main": "./out/extension",


### PR DESCRIPTION
Done to try and address a dependabot alert for underscore 1.8.3

