### PR TITLE
Bump pre-release maintversion to trigger CI beta build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.2022012601 (26-Jan-2022 pre-release)
+## 3.1.2022012602 (26-Jan-2022 pre-release)
 * Update README.
 * Automate pre-release publication to Marketplace.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "servermanager",
   "displayName": "InterSystems Server Manager",
-  "version": "3.1.2022012601",
+  "version": "3.1.2022012602",
   "preview": true,
   "publisher": "intersystems-community",
   "description": "Define connections to InterSystems servers. Browse and manage those servers.",


### PR DESCRIPTION
This PR bumps suffix in order to trigger the (hopefully) fixed beta pre-release CI.