### PR TITLE
USER as a namespace for getPortalUriWithToken

### DIFF
--- a/src/api/getPortalUriWithToken.ts
+++ b/src/api/getPortalUriWithToken.ts
@@ -24,7 +24,7 @@ export async function getPortalUriWithToken(target: BrowserTarget, name: string,
         let token = allTokens[target].get(name) || '';
 
         // Revalidate and extend existing token, or obtain a new one
-        const response = await makeRESTRequest("POST", spec, { apiVersion: 1, namespace: '%SYS', path:'/action/query' }, { query: 'select %Atelier_v1_Utils.General_GetCSPToken(?, ?) token', parameters: [PORTAL_HOME, token]});
+        const response = await makeRESTRequest("POST", spec, { apiVersion: 1, namespace: 'USER', path:'/action/query' }, { query: 'select %Atelier_v1_Utils.General_GetCSPToken(?, ?) token', parameters: [PORTAL_HOME, token]});
 
         if (!response) {
             // User will have to enter credentials


### PR DESCRIPTION
For https://github.com/intersystems-community/intersystems-servermanager/issues/138

While %SYS namespace always exists, users might (and in many cases should) lack direct access to it.
This merge request replaces the default with USER namespace which is available to everyone by default and extremely likely to exist.

This PR is a temp fix for https://github.com/intersystems-community/intersystems-servermanager/issues/138