### PR TITLE
Reuse session-cached username if server definition lacks one

### DIFF
--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -42,7 +42,12 @@ export async function getServerSpec(name: string, scope?: vscode.ConfigurationSc
     }
     else {
 
-        // Obtain a username (including blank to try connecting anonymously)
+        // Use cached username if appropriate
+        if (!server.username && credentialCache[name]) {
+          server.username = credentialCache[name].username;
+        }
+
+        // Prompt for a username if necessary (including blank to try connecting anonymously)
         if (!server.username) {
             await vscode.window
             .showInputBox({


### PR DESCRIPTION
This PR resolves#124, not by making username a mandatory property of a server definition but by reusing the one entered previously in the session.