### PR TITLE
Migrate Server Manager 2 stored passwords

### DIFF
--- a/package.json
+++ b/package.json
@@ -644,12 +644,12 @@
         },
         {
           "command": "intersystems-community.servermanager.storePassword",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./ && config.intersystemsServerManager.authentication.provider != intersystems-server-credentials",
           "group": "2_password@10"
         },
         {
           "command": "intersystems-community.servermanager.clearPassword",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./ && config.intersystemsServerManager.authentication.provider != intersystems-server-credentials",
           "group": "2_password@20"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "onCommand:intersystems-community.servermanager.addServer",
     "onCommand:intersystems-community.servermanager.storePassword",
     "onCommand:intersystems-community.servermanager.clearPassword",
+    "onCommand:intersystems-community.servermanager.migratePasswords",
     "onCommand:intersystems-community.servermanager.importServers",
     "onCommand:intersystems-community.servermanager-credentials.testLogin",
     "onCommand:intersystems-community.servermanager-credentials.testScopedLogin",
@@ -324,6 +325,11 @@
         "title": "Clear Password from Keychain"
       },
       {
+        "command": "intersystems-community.servermanager.migratePasswords",
+        "category": "InterSystems Server Manager",
+        "title": "Migrate Legacy Passwords"
+      },
+      {
         "command": "intersystems-community.servermanager.importServers",
         "category": "InterSystems Server Manager",
         "title": "Import Servers from Windows Registry"
@@ -478,6 +484,18 @@
         {
           "command": "intersystems-community.servermanager.importServers",
           "when": "isWindows"
+        },
+        {
+          "command": "intersystems-community.servermanager.migratePasswords",
+          "when": "config.intersystemsServerManager.authentication.provider == intersystems-server-credentials"
+        },
+        {
+          "command": "intersystems-community.servermanager.storePassword",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.clearPassword",
+          "when": "false"
         },
         {
           "command": "intersystems-community.servermanager.addToStarred",

--- a/src/commands/managePasswords.ts
+++ b/src/commands/managePasswords.ts
@@ -96,12 +96,12 @@ export async function migratePasswords(secretStorage: vscode.SecretStorage): Pro
                   migratableCredentials.push(item);
                 }
             });
+
         if (migratableCredentials.length === 0) {
             const message = 'No remaining legacy stored passwords are eligible for migration.';
             const detail = 'They are either for servers with a password already stored in the new format, or for servers whose definition does not specify a username.'
             await vscode.window.showWarningMessage(message,
-                {modal: true, detail},
-                //{title: "OK", isCloseAffordance: true}
+                {modal: true, detail}
             );
         } else {
             const choices = await vscode.window.showQuickPick<IMigratePasswordItem>(migratableCredentials,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { getServerSummary } from "./api/getServerSummary";
 import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
 import { importFromRegistry } from "./commands/importFromRegistry";
-import { clearPassword, storePassword } from "./commands/managePasswords";
+import { clearPassword, migratePasswords, storePassword } from "./commands/managePasswords";
 import { cookieJar } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem } from "./ui/serverManagerView";
 
@@ -267,6 +267,11 @@ export function activate(context: vscode.ExtensionContext) {
                     _onDidChangePassword.fire(name);
                 }
             });
+        }),
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${extensionId}.migratePasswords`, async () => {
+            await migratePasswords(context.secrets);
         }),
     );
     context.subscriptions.push(


### PR DESCRIPTION
This PR implements #129 by adding a `Migrate Legacy Passwords` command.

It also removes from Command Palette the commands for storing and deleting legacy passwords, and only offers those in the server tree if using setting `"intersystemsServerManager.authentication.provider": "none"` to operate in legacy mode.