### PR TITLE
During Windows registry import, set passwords in new v3+ place

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,7 +332,7 @@ export function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(
         vscode.commands.registerCommand(`${extensionId}.importServers`, async () => {
-            await importFromRegistry();
+            await importFromRegistry(context.secrets);
             view.refreshTree();
         }),
     );


### PR DESCRIPTION
This PR fixes #130

It also fixes a bug introduced when #107 was fixed, which stopped machine-level server definitions from being found.