### PR TITLE
resolve getServerSpec promise on Escape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "servermanager",
-  "version": "2.0.8-SNAPSHOT",
+  "version": "2.0.11-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "servermanager",
-      "version": "2.0.8-SNAPSHOT",
+      "version": "2.0.11-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
         "@types/vscode": "^1.55.0",
@@ -1988,6 +1988,9 @@
       },
       "engines": {
         "node": ">=4.8.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
       }
     },
     "node_modules/tslint/node_modules/diff": {


### PR DESCRIPTION
This PR fixes issue where user pressing Escape at getServerSpec's password prompt resulted in promise never resolving.