### PR TITLE
Write request error info to output channel

### DIFF
--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -8,6 +8,7 @@ import tough = require("tough-cookie");
 import * as vscode from "vscode";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
 import { IServerSpec } from "./extension";
+import logger from "./logger";
 
 axiosCookieJarSupport(axios);
 
@@ -134,6 +135,7 @@ export async function makeRESTRequest(
         return respdata;
     } catch (error) {
         console.log(error);
+        logger.error(`${method} ${url} failed: ${error.message} (${error.code})`);
         return undefined;
     }
 }


### PR DESCRIPTION
This PR makes the pre-release write an output channel message upon request failure, to help with investigation of #153.