### PR TITLE
 Use a cookie jar per connection to handle correctly multiple connection definitions to same server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
 import { importFromRegistry } from "./commands/importFromRegistry";
 import { clearPassword, migratePasswords, storePassword } from "./commands/managePasswords";
-import { cookieJar } from "./makeRESTRequest";
+import { cookieJars } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem } from "./ui/serverManagerView";
 
 export const extensionId = "intersystems-community.servermanager";
@@ -68,7 +68,9 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.authentication.onDidChangeSessions((e) => {
             if (e.provider.id === AUTHENTICATION_PROVIDER) {
-                cookieJar.removeAllCookiesSync();
+                cookieJars.forEach((cookieJar) => {
+                    cookieJar.removeAllCookiesSync();
+                });
             }
         }),
     );

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -183,8 +183,7 @@ export async function logout(serverName: string) {
 
   // Make the request but don't do anything with the response or any errors
   try {
-      let respdata: AxiosResponse;
-      respdata = await axios.request(
+      await axios.request(
           {
               httpsAgent,
               jar: cookieJar,

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -14,7 +14,7 @@ axiosCookieJarSupport(axios);
 /**
  * Cookie jar for REST requests to InterSystems servers.
  */
-export const cookieJar: tough.CookieJar = new tough.CookieJar();
+export const cookieJars = new Map<string, tough.CookieJar>();
 
 export interface IAtelierRESTEndpoint {
     apiVersion: number;
@@ -39,6 +39,13 @@ export async function makeRESTRequest(
 
 	// Create the HTTPS agent
 	const httpsAgent = new https.Agent({ rejectUnauthorized: vscode.workspace.getConfiguration("http").get("proxyStrictSSL") });
+
+  const cookieUsername = server.username || '';
+  let cookieJar = cookieJars.get(cookieUsername);
+  if (!cookieJar) {
+    cookieJar =new tough.CookieJar();
+    cookieJars.set(cookieUsername, cookieJar);
+  }
 
 	// Build the URL
 	let url = server.webServer.scheme + "://" + server.webServer.host + ":" + String(server.webServer.port);

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -382,7 +382,7 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
             children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, element.name));
             credentialCache[name] = undefined;
         } else {
-            children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name));
+            children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec.username || 'UnknownUser'));
         }
     }
     return children;
@@ -418,6 +418,7 @@ export class NamespacesTreeItem extends FeatureTreeItem {
     constructor(
         element: ISMItem,
         serverName: string,
+        username: string
     ) {
         const parentFolderId = element.parent?.id || "";
         super({
@@ -426,7 +427,7 @@ export class NamespacesTreeItem extends FeatureTreeItem {
             label: "Namespaces",
             params: { serverName },
             parent: element.parent,
-            tooltip: `Namespaces you can access`,
+            tooltip: `Namespaces '${username}' can access`,
         });
         this.name = "Namespaces";
         this.contextValue = "namespaces";


### PR DESCRIPTION
This PR fixes #149 and #145.

With this change multiple `intersystems.servers` entries that point to the same server but specify different usernames will now each connect with the correct username (provided the /api/aterlier webapp doesn't permit Unauthenticated access), and will only show namespaces which the user can access.

As a bonus it also displays the connection's username in the tooltip on the Namespaces folder.

When user logs out of a connection from the VS Code Accounts menu we will attempt to release the server-side session license.