### PR TITLE
Fix publishing failure caused by leftover debug code in CI script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,9 +127,6 @@ jobs:
         id: set-version
         shell: bash
         run: |
-          # REMOVE BELOW AFTER TESTING
-          exit 1
-          # REMOVE ABOVE AFTER TESTING
           VERSION=${{ needs.build.outputs.version }}
           NEXT_VERSION=`echo $VERSION | awk -F. '/[0-9]+\./{$NF++;print}' OFS=.`
           tmp=$(mktemp)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1 (04-Oct-2022)
+* Fix publishing failure.
+
 ## 3.2.0 (03-Oct-2022)
 * Implement `intersystems-server-credentials` authentication provider.
 * Implement `Migrate Legacy Passwords` command (#146).


### PR DESCRIPTION
This PR fixes the 3.2.0 publishing failure and bumps to 3.2.1