### PR TITLE
Create @intersystems-community/intersystems-servermanager NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "servermanager",
-  "version": "3.1.2022062902-SNAPSHOT",
+  "version": "3.2.2-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "servermanager",
-      "version": "3.1.2022062902-SNAPSHOT",
+      "version": "3.2.2-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.24.0",
@@ -15,6 +15,7 @@
         "tough-cookie": "^4.0.0"
       },
       "devDependencies": {
+        "@intersystems-community/intersystems-servermanager": "^3.0.0",
         "@types/glob": "^7.1.1",
         "@types/keytar": "^4.4.2",
         "@types/mocha": "^9.0.0",
@@ -56,6 +57,12 @@
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
+    },
+    "node_modules/@intersystems-community/intersystems-servermanager": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.0.0.tgz",
+      "integrity": "sha512-0ayAJOqhu3FHO0J6EfaPpxM2YkPvDmKVrfq2g1siCzYclSqojL5g/EeT7AXCBetSBeVTVcTZeO+IBPMN0uAsBA==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -2475,6 +2482,12 @@
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@intersystems-community/intersystems-servermanager": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.0.0.tgz",
+      "integrity": "sha512-0ayAJOqhu3FHO0J6EfaPpxM2YkPvDmKVrfq2g1siCzYclSqojL5g/EeT7AXCBetSBeVTVcTZeO+IBPMN0uAsBA==",
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "tough-cookie": "^4.0.0"
       },
       "devDependencies": {
-        "@intersystems-community/intersystems-servermanager": "^3.0.0",
+        "@intersystems-community/intersystems-servermanager": "latest",
         "@types/glob": "^7.1.1",
         "@types/keytar": "^4.4.2",
         "@types/mocha": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "tough-cookie": "^4.0.0"
   },
   "devDependencies": {
+    "@intersystems-community/intersystems-servermanager": "^3.0.0",
     "@types/vscode": "^1.63.0",
     "@types/glob": "^7.1.1",
     "@types/keytar": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tough-cookie": "^4.0.0"
   },
   "devDependencies": {
-    "@intersystems-community/intersystems-servermanager": "^3.0.0",
+    "@intersystems-community/intersystems-servermanager": "latest",
     "@types/vscode": "^1.63.0",
     "@types/glob": "^7.1.1",
     "@types/keytar": "^4.4.2",

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IJSONServerSpec } from "../extension";
+import { IJSONServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { getServerNames } from "./getServerNames";
 
 export async function addServer(

--- a/src/api/getPortalUriWithToken.ts
+++ b/src/api/getPortalUriWithToken.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { Uri } from "vscode";
-import { extensionId, IServerSpec } from "../extension";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { extensionId } from "../extension";
 import { makeRESTRequest } from "../makeRESTRequest";
 
 export enum BrowserTarget {

--- a/src/api/getServerNames.ts
+++ b/src/api/getServerNames.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerName } from "../extension";
+import { IServerName } from "@intersystems-community/intersystems-servermanager";
 import { serverDetail } from "./getServerSummary";
 
 export function getServerNames(scope?: vscode.ConfigurationScope, sorted?: boolean): IServerName[] {

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { AUTHENTICATION_PROVIDER } from "../authenticationProvider";
 import { filePassword } from "../commands/managePasswords";
-import { IServerSpec } from "../extension";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { Keychain } from "../keychain";
 
 interface ICredentialSet {

--- a/src/api/getServerSummary.ts
+++ b/src/api/getServerSummary.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerName, IServerSpec } from "../extension";
+import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export function getServerSummary(name: string, scope?: vscode.ConfigurationScope): IServerName | undefined {
 	const server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as vscode from "vscode";
+import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { BrowserTarget, getPortalUriWithToken } from "./api/getPortalUriWithToken";
 import { getServerNames } from "./api/getServerNames";
@@ -15,34 +16,6 @@ import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, 
 
 export const extensionId = "intersystems-community.servermanager";
 export let globalState: vscode.Memento;
-
-export interface IServerName {
-	name: string;
-	description: string;
-	detail: string;
-}
-
-export interface IWebServerSpec {
-	scheme?: string;
-	host: string;
-	port: number;
-	pathPrefix?: string;
-}
-
-export interface IServerSpec {
-	name: string;
-	webServer: IWebServerSpec;
-	username?: string;
-	password?: string;
-	description?: string;
-}
-
-export interface IJSONServerSpec {
-	webServer: IWebServerSpec;
-	username?: string;
-	password?: string;
-	description?: string;
-}
 
 export function activate(context: vscode.ExtensionContext) {
 

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -7,7 +7,7 @@ import * as https from "https";
 import tough = require("tough-cookie");
 import * as vscode from "vscode";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { IServerSpec } from "./extension";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { getServerSpec } from "./api/getServerSpec";
 
 axiosCookieJarSupport(axios);

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
 import { credentialCache, getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
-import { IServerName } from "../extension";
+import { IServerName } from "@intersystems-community/intersystems-servermanager";
 import { makeRESTRequest } from "../makeRESTRequest";
 
 const SETTINGS_VERSION = "v1";

--- a/types/.npmignore
+++ b/types/.npmignore
@@ -1,0 +1,2 @@
+tsconfig.json
+*.tgz

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,11 @@
+# InterSystems Server Manager extension API interfaces and constants
+
+[![GitHub](https://img.shields.io/github/license/intersystems-community/intersystems-servermanager)](https://github.com/intersystems-community/intersystems-servermanager/blob/master/LICENSE)
+
+Package defining the interfaces used in the API that is published by the `intersystems-community.servermanager` [extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=intersystems-community.servermanager), plus constants associated with the extension.
+
+# Changelog
+
+### v3.0.0
+
+- First release, numbered to align with the first published version of Server Manager 3.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-export const EXTENSION_ID = 'intersystems-community.servermanager';
-export const AUTHENTICATION_PROVIDER = 'intersystems-server-credentials';
+export declare const EXTENSION_ID = 'intersystems-community.servermanager';
+export declare const AUTHENTICATION_PROVIDER = 'intersystems-server-credentials';
 
 export interface IServerName {
 	name: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,26 @@
+export const EXTENSION_ID = 'intersystems-community.servermanager';
+export const AUTHENTICATION_PROVIDER = 'intersystems-server-credentials';
+
+export interface IServerName {
+	name: string;
+	description: string;
+	detail: string;
+}
+
+export interface IWebServerSpec {
+	scheme?: string;
+	host: string;
+	port: number;
+	pathPrefix?: string;
+}
+
+export interface IJSONServerSpec {
+	webServer: IWebServerSpec;
+	username?: string;
+	password?: string;
+	description?: string;
+}
+
+export interface IServerSpec extends IJSONServerSpec {
+	name: string;
+}

--- a/types/index.js
+++ b/types/index.js
@@ -1,0 +1,2 @@
+module.exports = {
+  };

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,0 +1,230 @@
+{
+  "name": "@intersystems-community/intersystems-servermanager",
+  "version": "3.0.0-beta.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@intersystems-community/intersystems-servermanager",
+      "version": "3.0.0-beta.1",
+      "license": "MIT",
+      "devDependencies": {
+        "rimraf": "^3.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intersystems-community/intersystems-servermanager",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "InterSystems Server Manager VS Code extension API interfaces and constants",
   "types": "index.d.ts",
   "main": "index.js",

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@intersystems-community/intersystems-servermanager",
+  "version": "3.0.0",
+  "description": "InterSystems Server Manager VS Code extension API interfaces and constants",
+  "types": "index.d.ts",
+  "main": "index.js",
+  "license": "MIT",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "test:tsc": "tsc --noEmit -p ./tsconfig.json --skipLibCheck",
+    "prerelease": "rimraf *.tgz",
+    "release": "npm publish --tag latest --access public",
+    "prebeta": "rimraf *.tgz",
+    "beta": "npm publish --tag beta --access public"
+  },
+  "keywords": [
+    "intersystems"
+  ],
+  "authors": [
+    "John Murray <johnm@georgejames.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intersystems-community/intersystems-servermanager.git",
+    "directory": "types"
+  },
+  "bugs": {
+    "url": "https://github.com/intersystems-community/intersystems-servermanager/issues"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.0"
+  }
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "experimentalDecorators": true,
+    "lib": ["es6"],
+    "module": "commonjs",
+    "noEmit": true,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "target": "esnext",
+  },
+}


### PR DESCRIPTION
This PR adds an NPM package that other extensions can use when leveraging the API this extension publishes.

It also updates Server Manager to use this package, as a way of validating the package's correctness.