### PR TITLE
Bump NPM types package to 3.0.4 to fix exporting of constants

### DIFF
--- a/types/README.md
+++ b/types/README.md
@@ -6,6 +6,10 @@ Package defining the interfaces used in the API that is published by the `inters
 
 # Changelog
 
+### v3.0.4
+
+- Export constants correctly.
+
 ### v3.0.0
 
 - First release, numbered to align with the first published version of Server Manager 3.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-export declare const EXTENSION_ID = 'intersystems-community.servermanager';
-export declare const AUTHENTICATION_PROVIDER = 'intersystems-server-credentials';
+export const EXTENSION_ID: string;
+export const AUTHENTICATION_PROVIDER: string;
 
 export interface IServerName {
 	name: string;

--- a/types/index.js
+++ b/types/index.js
@@ -1,2 +1,4 @@
 module.exports = {
-  };
+	EXTENSION_ID: 'intersystems-community.servermanager',
+	AUTHENTICATION_PROVIDER: 'intersystems-server-credentials'
+};

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intersystems-community/intersystems-servermanager",
-  "version": "3.0.2",
+  "version": "3.0.4",
   "description": "InterSystems Server Manager VS Code extension API interfaces and constants",
   "types": "index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
This PR contains the changes already published in NPM package `@intersystems-community/intersystems-servermanager@3.0.4` to make the `EXTENSION_ID` and `AUTHENTICATION_PROVIDER` constants export correctly.