### PR TITLE
Add shortcut to Explorer section of Portal at namespace level

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "multi-root ready"
   ],
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.75.0"
   },
   "icon": "images/logo.png",
   "categories": [
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@intersystems-community/intersystems-servermanager": "latest",
-    "@types/vscode": "^1.63.0",
+    "@types/vscode": "^1.75.0",
     "@types/glob": "^7.1.1",
     "@types/keytar": "^4.4.2",
     "@types/mocha": "^9.0.0",
@@ -65,14 +65,7 @@
   },
   "main": "./out/extension",
   "activationEvents": [
-    "onAuthenticationRequest:intersystems-servermanager-credentials",
-    "onView:intersystems-community_servermanager",
-    "onCommand:intersystems-community.servermanager.refreshTree",
-    "onCommand:intersystems-community.servermanager.addServer",
-    "onCommand:intersystems-community.servermanager.storePassword",
-    "onCommand:intersystems-community.servermanager.clearPassword",
-    "onCommand:intersystems-community.servermanager.migratePasswords",
-    "onCommand:intersystems-community.servermanager.importServers"
+    "onAuthenticationRequest:intersystems-servermanager-credentials"
   ],
   "contributes": {
     "viewsContainers": {
@@ -293,6 +286,16 @@
         "icon": "$(tools)"
       },
       {
+        "command": "intersystems-community.servermanager.openPortalExplorerTab",
+        "title": "Open Management Portal's Class Utilities in Tab",
+        "icon": "$(tools)"
+      },
+      {
+        "command": "intersystems-community.servermanager.openPortalExplorerExternal",
+        "title": "Open in External Browser",
+        "icon": "$(link-external)"
+      },
+      {
         "command": "intersystems-community.servermanager.retryServer",
         "title": "Refresh",
         "icon": "$(refresh)"
@@ -464,6 +467,14 @@
           "when": "false"
         },
         {
+          "command": "intersystems-community.servermanager.openPortalExplorerExternal",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.openPortalExplorerTab",
+          "when": "false"
+        },
+        {
           "command": "intersystems-community.servermanager.retryServer",
           "when": "false"
         },
@@ -612,6 +623,12 @@
           "command": "intersystems-community.servermanager.openPortalExternal",
           "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./",
           "group": "inline@90"
+        },
+        {
+          "command": "intersystems-community.servermanager.openPortalExplorerTab",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "group": "inline@80",
+          "alt": "intersystems-community.servermanager.openPortalExplorerExternal"
         },
         {
           "command": "intersystems-community.servermanager.retryServer",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,11 +106,45 @@ export function activate(context: vscode.ExtensionContext) {
 					if (uriWithToken) {
 						//
 						// It is essential to pass skipEncoding=true when converting the uri to a string,
-						// otherwise the encoding done within Simple Browser / webview causes double-encoding
-						// of the querystring.
+						// otherwise the querystring's & and = get encoded.
 						vscode.commands.executeCommand("simpleBrowser.show", uriWithToken.toString(true));
 					}
 				});
+			}
+		}),
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(`${extensionId}.openPortalExplorerExternal`, (namespaceTreeItem?: NamespaceTreeItem) => {
+			if (namespaceTreeItem) {
+				const pathParts = namespaceTreeItem.id?.split(":");
+				if (pathParts && pathParts.length === 4) {
+					const serverName = pathParts[1];
+					const namespace = pathParts[3];
+					getPortalUriWithToken(BrowserTarget.EXTERNAL, serverName, "/csp/sys/exp/%25CSP.UI.Portal.ClassList.zen", namespace).then((uriWithToken) => {
+						if (uriWithToken) {
+							vscode.env.openExternal(uriWithToken);
+						}
+					});
+				}
+			}
+		}),
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(`${extensionId}.openPortalExplorerTab`, (namespaceTreeItem?: NamespaceTreeItem) => {
+			if (namespaceTreeItem) {
+				const pathParts = namespaceTreeItem.id?.split(":");
+				if (pathParts && pathParts.length === 4) {
+					const serverName = pathParts[1];
+					const namespace = pathParts[3];
+					getPortalUriWithToken(BrowserTarget.SIMPLE, serverName, "/csp/sys/exp/%2525CSP.UI.Portal.ClassList.zen", namespace).then((uriWithToken) => {
+						if (uriWithToken) {
+							//
+							// It is essential to pass skipEncoding=true when converting the uri to a string,
+							// otherwise the querystring's & and = get encoded.
+							vscode.commands.executeCommand("simpleBrowser.show", uriWithToken.toString(true));
+						}
+					});
+				}
 			}
 		}),
 	);


### PR DESCRIPTION
This PR adds a button alongside each namespace. An ordinary click opens the Class Explorer section of Portal in the Simple Browser tab. An alt-click loads this in the external browser. For reasons of space I opted for a single button with alt-modifier instead of the pair that already appear at server level.

If the portal web apps haven't been modified to suit Simple Browser we now notify the user.

A key motivation for this enhancement is to help Studio refugees whose workflows involve a lot of exporting and importing of XML bundles.

Export and import won't work properly in Simple Browser unless/until InterSystems make some changes in %CSP.UI.Portal.* classes so the no-session-cookie mode is handled correctly. On one of my servers I have already made enough changes to achieve export/import round-tripping. I can provide details.