### PR TITLE
Treat same username on different servers as distinct accounts (fix #194)

### DIFF
--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -14,7 +14,7 @@ export class ServerManagerAuthenticationSession implements AuthenticationSession
 		const canonicalUserName = userName.toLowerCase();
 		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
 		this.accessToken = password;
-		this.account = { id: canonicalUserName, label: `${userName} on ${serverName}` };
+		this.account = { id: `${serverName}/${canonicalUserName}`, label: `${userName} on ${serverName}` };
 		this.scopes = [serverName, canonicalUserName];
 	}
 }


### PR DESCRIPTION
This PR fixes #194.

Prior to this change, if user 'jdoe' has signed in to servers 'iris-1' and 'iris-2' there would be only one InterSystems Server Credential  entry for 'jdoe' in VS Code's Accounts context menu, and using the Sign Out action from its submenu would offer to delete stored 'jdoe' passwords for every server they existed for.

This change means 'jdoe on iris-1' and 'jdoe on iris-2' are treated as separate accounts.