### PR TITLE
Remove default servers and the /hideEmbedded switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,7 @@ In this example two connections have been defined:
 		},
 		"description": "My local IRIS instance"
 	},
-	"/default": "my-local",
-	"/hideEmbeddedEntries": true
+	"/default": "my-local"
 }
 ```
 
@@ -184,8 +183,6 @@ The JSON editor offers the usual [IntelliSense](https://code.visualstudio.com/do
 Notice how you can add a `description` property to each connection. This will be shown in the hover in Server Manager's tree, and alongside the entry if a server quickpick is used.
 
 Servers are displayed in the quickpick in the order they are defined in the JSON file. The exception is that if a server name is set as the value of the `/default` property (see example above) it will be shown first in the list.
-
-A set of embedded servers with names beginning `default~` will appear at the end of the lists unless you add the property `"/hideEmbeddedEntries": true` to your `intersystems.server` object to hide them (see above).
 
 ---
 
@@ -197,11 +194,9 @@ These features use VS Code's extension-private global state storage. Data is not
 
 ### The 'All Servers' Folder
 
-The `All Servers` tree respects the optional `/default` and `/hideEmbeddedEntries` settings in the `intersystems.servers` JSON.
+The `All Servers` tree respects the optional `/default` setting in the `intersystems.servers` JSON.
 
 If a server has been named in `/default` it is promoted to the top of the list, which is otherwise presented in alphabetical order.
-
-Embedded entries (built-in default ones) are demoted to the end of the list, or omitted completely if `/hideEmbeddedEntries` is true.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -101,33 +101,6 @@
             "description": "InterSystems servers that other extensions connect to. Each property of this object names a server and holds nested properties specifying how to connect to it.",
             "markdownDescription": "[InterSystems](https://www.intersystems.com) servers that other extensions connect to. Each property of this object names a server and holds nested properties specifying how to connect to it. Server names may only contain characters 'A' to 'Z', 'a' to 'z', digits, '-', '.', '_' and '~' characters.",
             "scope": "resource",
-            "default": {
-              "default~iris": {
-                "webServer": {
-                  "scheme": "http",
-                  "host": "127.0.0.1",
-                  "port": 52773
-                },
-                "description": "Connection to local InterSystems IRIS™ installed with default settings."
-              },
-              "default~cache": {
-                "webServer": {
-                  "scheme": "http",
-                  "host": "127.0.0.1",
-                  "port": 57772
-                },
-                "description": "Connection to local InterSystems Caché installed with default settings."
-              },
-              "default~ensemble": {
-                "webServer": {
-                  "scheme": "http",
-                  "host": "127.0.0.1",
-                  "port": 57772
-                },
-                "description": "Connection to local InterSystems Ensemble installed with default settings."
-              },
-              "/default": "default~iris"
-            },
             "patternProperties": {
               "^[a-z0-9-_~]+$": {
                 "type": "object",
@@ -237,10 +210,6 @@
               "/default": {
                 "type": "string",
                 "description": "Name of the server to promote to the top of pick lists."
-              },
-              "/hideEmbeddedEntries": {
-                "type": "boolean",
-                "description": "Do not append the built-in 'default~*' server definitions to pick lists."
               }
             },
             "additionalProperties": false

--- a/src/api/getServerSummary.ts
+++ b/src/api/getServerSummary.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode";
 import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { legacyEmbeddedServer } from "./getServerSpec";
 
 export function getServerSummary(name: string, scope?: vscode.ConfigurationScope): IServerName | undefined {
-	const server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name);
+	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
+	const server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) || legacyEmbeddedServer(name);
 	if (!server) {
 		return undefined;
 	}


### PR DESCRIPTION
This PR closes #203

Workspaces or `objectscript.conn` settings that currently use a default server definition should continue to work despite those definitions no longer existing in package.json