### PR TITLE
Prepare 3.6.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
           git config --global user.email 'bot@users.noreply.github.com'
           jq --arg version "${NEXT_VERSION}-SNAPSHOT" '.version = $version' package.json > "$tmp" && mv "$tmp" package.json
           git add package.json
-          git commit -m 'auto bump version with release'
+          git commit -m 'auto bump version with release [skip ci]'
           jq --arg version "$VERSION" '.version = $version' package.json > "$tmp" && mv "$tmp" package.json
           jq 'del(.enableProposedApi,.enabledApiProposals)' package.json > "$tmp" && mv "$tmp" package.json
           npm install

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
           git config --global user.email 'bot@users.noreply.github.com'
           jq --arg version "${NEXT_VERSION}-SNAPSHOT" '.version = $version' package.json > "$tmp" && mv "$tmp" package.json
           git add package.json
-          git commit -m 'auto bump version after pre-release'
+          git commit -m 'auto bump version after pre-release [skip ci]'
           jq --arg version "$VERSION" '.version = $version' package.json > "$tmp" && mv "$tmp" package.json
           npm install
           jq 'del(.enableProposedApi,.enabledApiProposals)' package.json > "$tmp" && mv "$tmp" package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.1 (30-May-2024)
+* Don't attempt to open the Management Portal in the Simple Browser for IRIS 2024.1+ (#223).
+* Updated dependencies.
+
 ## 3.6.0 (29-Jan-2024)
 * Change "Starred" to "Favorites" in command titles (#210).
 * Add 'Remove from Recent' to context menu of Recent entry (#213).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.6.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.5",
+        "axios": "^1.7.2",
         "node-cmd": "^5.0.0"
       },
       "devDependencies": {
@@ -663,11 +663,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint-fix": "tslint --project tsconfig.json -t verbose --fix"
   },
   "dependencies": {
-    "axios": "^1.6.5",
+    "axios": "^1.7.2",
     "node-cmd": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Also skips ci for the version bump robot commit. Since this extension doesn't use proposed APIs we don't need a beta version that's identical to the released version.