### PR TITLE
If connect with stored password fails, delete and re-prompt

### DIFF
--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,31 +1,17 @@
 import * as vscode from "vscode";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
-interface ICredentialSet {
-	username: string;
-	password: string;
-}
-
-export let credentialCache = new Map<string, ICredentialSet>();
-
 /**
  * Get a server specification.
  *
  * @param name The name.
  * @param scope The settings scope to use for the lookup.
- * @param flushCredentialCache Flush the session's cache of credentials obtained from keystore and/or user prompting.
- * @param noCredentials Set username and password as undefined; do not fetch credentials from anywhere.
  * @returns Server specification or undefined.
  */
 export async function getServerSpec(
 	name: string,
 	scope?: vscode.ConfigurationScope,
-	flushCredentialCache: boolean = false,
-	noCredentials: boolean = false,
 ): Promise<IServerSpec | undefined> {
-	if (flushCredentialCache) {
-		credentialCache[name] = undefined;
-	}
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
 	let server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) || legacyEmbeddedServer(name);
 

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -66,7 +66,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 
 		if (sessions.length === 1) {
-			sessions = sessions.filter(async (session) => await this._isStillValid(session));
+			if (!(await this._isStillValid(sessions[0]))) {
+				sessions = [];
+			}
 		}
 		return sessions || [];
 	}
@@ -214,8 +216,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			serverSpec.username = session.userName;
 			serverSpec.password = session.accessToken;
 			const response = await makeRESTRequest("HEAD", serverSpec);
-			if (response?.status !== 200) {
-				this._removeSession(session.id, true);
+			if (response?.status === 401) {
+				await this._removeSession(session.id, true);
 				return false;
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,7 +254,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (pathParts && pathParts.length === 4) {
 				const serverName = pathParts[1];
 				const namespace = pathParts[3];
-				const serverSpec = await getServerSpec(serverName, undefined, undefined, true);
+				const serverSpec = await getServerSpec(serverName);
 				if (serverSpec) {
 					const ISFS_ID = "intersystems-community.vscode-objectscript";
 					const isfsExtension = vscode.extensions.getExtension(ISFS_ID);
@@ -379,18 +379,18 @@ export function activate(context: vscode.ExtensionContext) {
 		/**
 		 * Get specification for the named server.
 		 *
-		 * If the `"intersystemsServerManager.authentication.provider"` setting is "intersystems-server-credentials":
-		 *  - the returned object will not contain `password`. To get this:
+		 *  The returned object will not contain `password`. To get that:
 		 * ```
-		 *      const session = await vscode.authentication.getSession('intersystems-server-credentials', [serverSpec.name, serverSpec.username]);
+		 *      const session: vscode.AuthenticationSession = await vscode.authentication.getSession('intersystems-server-credentials', [serverSpec.name, serverSpec.username]);
 		 * ```
 		 *    The `accessToken` property of the returned [`AuthenticationSession`](https://code.visualstudio.com/api/references/vscode-api#AuthenticationSession) is the password.
-		 *  - `flushCredentialsCache` param will be ignored;
-		 *  - `noCredentials` property of `options` param has no effect;
+		 *
+		 *  The `flushCredentialsCache` param is obsolete and has no effect;
+		 *  The `noCredentials` property of `options` param is obsolete and has no effect;
 		 *
 		 * @param name Name of the server, used as the key into the 'intersystems.servers' settings object
 		 * @param scope Settings scope to look in.
-		 * @param flushCredentialCache If passed as true, flush extension's credential cache.
+		 * @param flushCredentialCache Obsolete, has no effect.
 		 * @param options
 		 * @returns { IServerSpec } Server specification object.
 		 */
@@ -398,9 +398,9 @@ export function activate(context: vscode.ExtensionContext) {
 			name: string,
 			scope?: vscode.ConfigurationScope,
 			flushCredentialCache: boolean = false,
-			options?: { hideFromRecents?: boolean, noCredentials?: boolean },
+			options?: { hideFromRecents?: boolean, /* Obsolete */ noCredentials?: boolean },
 		): Promise<IServerSpec | undefined> {
-			const spec = await getServerSpec(name, scope, flushCredentialCache, options?.noCredentials);
+			const spec = await getServerSpec(name, scope);
 			if (spec && !options?.hideFromRecents) {
 				await view.addToRecents(name);
 			}

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -176,7 +176,7 @@ export async function makeRESTRequest(
  */
 export async function logout(serverName: string) {
 
-	const server = await getServerSpec(serverName, undefined, false, true);
+	const server = await getServerSpec(serverName, undefined);
 
 	if (!server) {
 		return;

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -165,7 +165,7 @@ export async function makeRESTRequest(
 		return respdata;
 	} catch (error) {
 		console.log(error);
-		return undefined;
+		return error.response;
 	}
 }
 

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -383,8 +383,13 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 			return undefined;
 		}
 
-		const response = await makeRESTRequest("HEAD", serverSpec);
-		if (!response || response.status !== 200) {
+		let response = await makeRESTRequest("HEAD", serverSpec);
+		if (response?.status === 401) {
+			// Authentication error, so retry in case first attempt cleared a no-longer-valid stored password
+			serverSpec.password = undefined;
+			response = await makeRESTRequest("HEAD", serverSpec);
+		}
+		if (response?.status !== 200) {
 			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser'));
 		} else {
 			children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec.username || 'UnknownUser'));
@@ -458,11 +463,11 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 		}
 
 		const response = await makeRESTRequest("GET", serverSpec);
-		if (!response || response.status !== 200) {
+		if (response?.status !== 200) {
 			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser'));
 		} else {
 			const serverApiVersion = response.data.result.content.api;
-			response.data.result.content.namespaces.map((namespace) => {
+			response.data.result.content.namespaces.map((namespace: string) => {
 				children.push(new NamespaceTreeItem({ parent: element, label: name, id: name }, namespace, name, serverApiVersion));
 			});
 		}
@@ -555,7 +560,7 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: any): Promi
 			{ apiVersion: 1, namespace: params.ns, path: "/action/query" },
 			{ query: "SELECT Name, Description FROM %Studio.Project", parameters: [] }
 		);
-		if (response !== undefined) {
+		if (response?.status === 200) {
 			if (response.data.result.content === undefined) {
 				let message;
 				if (response.data.status?.errors[0]?.code === 5540) {
@@ -641,7 +646,7 @@ async function namespaceWebApps(element: ProjectsTreeItem, params?: any): Promis
 			serverSpec,
 			{ apiVersion: 1, namespace: "%SYS", path: `/cspapps/${params.ns}` }
 		);
-		if (response !== undefined) {
+		if (response?.status === 200) {
 			if (response.data.result.content === undefined) {
 				vscode.window.showErrorMessage(response.data.status.summary);
 				return undefined;

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
-import { credentialCache, getServerSpec } from "../api/getServerSpec";
+import { getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
 import { IServerName } from "@intersystems-community/intersystems-servermanager";
 import { makeRESTRequest } from "../makeRESTRequest";
@@ -386,7 +386,6 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 		const response = await makeRESTRequest("HEAD", serverSpec);
 		if (!response || response.status !== 200) {
 			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser'));
-			credentialCache[name] = undefined;
 		} else {
 			children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec.username || 'UnknownUser'));
 		}
@@ -461,7 +460,6 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 		const response = await makeRESTRequest("GET", serverSpec);
 		if (!response || response.status !== 200) {
 			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser'));
-			credentialCache[params.serverName] = undefined;
 		} else {
 			const serverApiVersion = response.data.result.content.api;
 			response.data.result.content.namespaces.map((namespace) => {


### PR DESCRIPTION
This PR fixes #233

To test:
1. Have a connection with a saved password that works (Namespaces folder appears when server is expanded).
2. In IRIS Portal, change this user's password.
3. Reload VS Code window and try to expand the same server.

You should be immediately prompted to allow use of the credentials service, then for the user's password. Enter the new one and save it. Namespaces folder should appear.