### PR TITLE
Show `objectscript.conn.docker-compose` type connections under 'Current' node

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,8 @@ import { logout, serverSessions } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
 
 export const extensionId = "intersystems-community.servermanager";
+export const OBJECTSCRIPT_EXTENSIONID = "intersystems-community.vscode-objectscript";
+
 export let globalState: vscode.Memento;
 
 export function getAccountFromParts(serverName: string, userName?: string): vscode.AuthenticationSessionAccountInformation | undefined {
@@ -262,18 +264,17 @@ export function activate(context: vscode.ExtensionContext) {
 				const namespace = pathParts[3];
 				const serverSpec = await getServerSpec(serverName);
 				if (serverSpec) {
-					const ISFS_ID = "intersystems-community.vscode-objectscript";
-					const isfsExtension = vscode.extensions.getExtension(ISFS_ID);
+					const isfsExtension = vscode.extensions.getExtension(OBJECTSCRIPT_EXTENSIONID);
 					if (isfsExtension) {
 						if (!isfsExtension.isActive) {
 							await isfsExtension.activate();
 							if (!isfsExtension.isActive) {
-								vscode.window.showErrorMessage(`${ISFS_ID} could not be activated.`, "Close");
+								vscode.window.showErrorMessage(`${OBJECTSCRIPT_EXTENSIONID} could not be activated.`, "Close");
 								return;
 							}
 						}
 					} else {
-						vscode.window.showErrorMessage(`${ISFS_ID} is not installed.`, "Close");
+						vscode.window.showErrorMessage(`${OBJECTSCRIPT_EXTENSIONID} is not installed.`, "Close");
 						return;
 					}
 


### PR DESCRIPTION
This PR closes #187

For example:

![image](https://github.com/user-attachments/assets/0f266dda-a1c2-4c0e-a57d-2c783d68ed39)

This workspace consists of 2 local folders. Each contains a docker-compose.yml and a Dockerfile plus a .vscode/settings.json with an `objectscript.conn` referencing the corresponding Docker service.

The enhancement makes the two docker servers appear in the Current node of the tree. The (dynamic) local port for each is displayed.

Their namespaces can be browsed in Server Manager in the usual manner. Lite Terminals can be launched, and isfs or isfs-readonly folders can be added to the workspace.

This enhancement depends on a related change in the ObjectScript extension (https://github.com/intersystems-community/vscode-objectscript/pull/1471)

The VSIX built from this PR should work OK with ObjectScript VSIXes that don't contain the relevant change, and vice versa. However the new features will only become available when both extensions have been updated.