### PR TITLE
Add button to namespace nodes to create category folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,6 +372,16 @@
         "command": "intersystems-community.servermanager.viewWebApp",
         "title": "View Files in Web Application",
         "icon": "$(eye)"
+      },
+      {
+        "command": "intersystems-community.servermanager.editCategories",
+        "title": "Edit Code in Namespace by Category",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "intersystems-community.servermanager.viewCategories",
+        "title": "View Code in Namespace by Category",
+        "icon": "$(list-tree)"
       }
     ],
     "submenus": [
@@ -503,6 +513,14 @@
         {
           "command": "intersystems-community.servermanager.viewWebApp",
           "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.editCategories",
+          "when": "false"
+        },
+        {
+          "command": "intersystems-community.servermanager.viewCategories",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -614,6 +632,12 @@
           "command": "intersystems-community.servermanager.removeFromRecent",
           "when": "view == intersystems-community_servermanager && viewItem =~ /^recent.server./",
           "group": "2_manage@10"
+        },
+        {
+          "command": "intersystems-community.servermanager.editCategories",
+          "alt": "intersystems-community.servermanager.viewCategories",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "group": "inline@30"
         }
       ]
     }


### PR DESCRIPTION
This PR fixes https://github.com/intersystems-community/vscode-objectscript/issues/1161. I have three questions that I'd like to resolve before merging:

1. Should I change the name of the command? This is the best I could come up with without referencing Studio.
2. Should the icon change when `Alt` is pressed? I couldn't find a good one to express "tree, but readonly".
3. I think that five inline icons is too many, and I'd like to remove the SMP link one. Thoughts?