### PR TITLE
Introduce an ellipsis submenu and demote Open Portal to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,9 +378,26 @@
       {
         "id": "intersystems-community.servermanager.iconColor",
         "label": "Set Icon Color"
+      },
+      {
+        "id": "intersystems-community.servermanager.moreActions",
+        "label": "More Actions...",
+        "icon": "$(ellipsis)"
       }
     ],
     "menus": {
+      "intersystems-community.servermanager.moreActions": [
+        {
+          "command": "intersystems-community.servermanager.openPortalTab",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./",
+          "group": "1_builtin@10"
+        },
+        {
+          "command": "intersystems-community.servermanager.openPortalExplorerExternal",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "group": "1_builtin@10"
+        }
+      ],
       "intersystems-community.servermanager.iconColor": [
         {
           "command": "intersystems-community.servermanager.setIconRed",
@@ -581,19 +598,14 @@
           "group": "inline@20"
         },
         {
-          "command": "intersystems-community.servermanager.openPortalTab",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./",
-          "group": "inline@80"
-        },
-        {
           "command": "intersystems-community.servermanager.openPortalExternal",
           "when": "view == intersystems-community_servermanager && viewItem =~ /\\.server\\./",
           "group": "inline@90"
         },
         {
-          "command": "intersystems-community.servermanager.openPortalExplorerExternal",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
-          "group": "inline@80"
+          "submenu": "intersystems-community.servermanager.moreActions",
+          "when": "view == intersystems-community_servermanager",
+          "group": "inline@999"
         },
         {
           "command": "intersystems-community.servermanager.retryServer",


### PR DESCRIPTION
This PR implements a submenu named `intersystems-community.servermanager.moreActions` which this and other extensions can contribute commands to, causing a "More Actions..." ellipsis button to appear at the end of a row's buttons if any of the submenu's commands have a true when clause.

We use this to demote one action from a server-level row and one from a namespace-level row. For example (namespace row):

![image](https://github.com/user-attachments/assets/9922d998-db2d-4dad-b58b-84798e451c07)
