### PR TITLE
Try to end /api/atelier web sessions when extension deactivates

### DIFF
--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -16,7 +16,7 @@ import {
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
-import { makeRESTRequest } from "./makeRESTRequest";
+import { logout, makeRESTRequest } from "./makeRESTRequest";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -230,6 +230,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				await this._removeSession(session.id, true);
 				return false;
 			}
+			// Immediately log out the session created by credentials test
+			await logout(session.serverName);
 		}
 		this._checkedSessions.push(session);
 		return true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
 	// Do our best to log out of all sessions
+
+	const promises: Promise<any>[] = [];
 	for (const serverSession of serverSessions) {
-		await logout(serverSession[1].serverName);
+		promises.push(logout(serverSession[1].serverName));
 	}
+	await Promise.allSettled(promises);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { importFromRegistry } from "./commands/importFromRegistry";
 import { ServerManagerView } from "./ui/serverManagerView";
 import { commonActivate, extensionId } from "./commonActivate";
+import { logout, serverSessions } from "./makeRESTRequest";
 
 export function activate(context: vscode.ExtensionContext) {
 	const view = new ServerManagerView(context);
@@ -20,4 +21,9 @@ export function activate(context: vscode.ExtensionContext) {
 	return commonActivate(context, view);
 }
 
-export function deactivate() { }
+export async function deactivate() {
+	// Do our best to log out of all sessions
+	for (const serverSession of serverSessions) {
+		await logout(serverSession[1].serverName);
+	}
+}

--- a/src/web-extension.ts
+++ b/src/web-extension.ts
@@ -3,12 +3,21 @@
 import * as vscode from "vscode";
 import { ServerManagerView } from "./ui/serverManagerView";
 import { commonActivate } from "./commonActivate";
+import { logout, serverSessions } from "./makeRESTRequest";
 
 export function activate(context: vscode.ExtensionContext) {
-    const view = new ServerManagerView(context);
+	const view = new ServerManagerView(context);
 
-    // Common activation steps
-    return commonActivate(context, view);
+	// Common activation steps
+	return commonActivate(context, view);
 }
 
-export function deactivate() { }
+export async function deactivate() {
+	// Do our best to log out of all sessions
+
+	const promises: Promise<any>[] = [];
+	for (const serverSession of serverSessions) {
+		promises.push(logout(serverSession[1].serverName));
+	}
+	await Promise.allSettled(promises);
+}


### PR DESCRIPTION
This PR makes the extension try to end its /api/atelier web sessions when deactivating (e.g. exiting VS Code or running `Developer: Reload Window`)