### PR TITLE
Show servers defined in workspace folder settings in `All Servers` UI

### DIFF
--- a/src/api/getServerNames.ts
+++ b/src/api/getServerNames.ts
@@ -16,6 +16,7 @@ export function getServerNames(scope?: vscode.ConfigurationScope, sorted?: boole
 				description: `${servers[myDefault].description || ""} (default)`.trim(),
 				detail: serverDetail(servers[myDefault]),
 				name: myDefault,
+				scope,
 			});
 		}
 
@@ -26,15 +27,14 @@ export function getServerNames(scope?: vscode.ConfigurationScope, sorted?: boole
 					description: servers[key].description || "",
 					detail: serverDetail(servers[key]),
 					name: key,
+					scope,
 				});
 			}
 		}
 	}
 
 	// If requested, sort what we found
-	if (sorted) {
-		names = names.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
-	}
+	if (sorted) names.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
 
 	// Append them
 	allNames.push(...names);

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -295,6 +295,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
         vscode.commands.registerCommand(`${extensionId}.viewWebApp`, async (webAppTreeItem?: WebAppTreeItem) => {
             await addWorkspaceFolderAsync(true, true, <NamespaceTreeItem>webAppTreeItem?.parent?.parent, undefined, webAppTreeItem?.name);
         }),
+        vscode.workspace.onDidChangeWorkspaceFolders(() => view.refreshTree()),
         // Listen for relevant configuration changes
         vscode.workspace.onDidChangeConfiguration((e) => {
             if (e.affectsConfiguration("intersystems.servers") || e.affectsConfiguration("objectscript.conn")) {

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -261,14 +261,16 @@ export class SMTreeItem extends vscode.TreeItem {
 
 function allServers(treeItem: SMTreeItem, params?: any): ServerTreeItem[] {
 	const children: ServerTreeItem[] = [];
-	const getAllServers = (sorted?: boolean): ServerTreeItem[] => {
-		const serverNames = getServerNames(undefined, sorted);
-		return serverNames.map((serverName) => {
-			return new ServerTreeItem({ label: serverName.name, id: serverName.name, parent: treeItem }, serverName);
-		});
-	};
-
-	getAllServers(params.sorted).map((server) => children.push(server));
+	const wsServerNames = getServerNames(undefined);
+	children.push(...wsServerNames.map((wss) => {
+		return new ServerTreeItem({ label: wss.name, id: wss.name, parent: treeItem }, wss);
+	}));
+	vscode.workspace.workspaceFolders?.map((wf) => {
+		children.push(...getServerNames(wf).filter((wfs) => !wsServerNames.some((wss) => wss.name == wfs.name)).map((wfs) => {
+			return new ServerTreeItem({ label: `${wfs.name} (${wf.name})`, id: wfs.name, parent: treeItem }, wfs);
+		}));
+	});
+	if (params?.sorted) children.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
 	return children;
 }
 


### PR DESCRIPTION
Servers that come from a workspace folder will have the folder name in parentheses following the name, but only in the `All Servers` tree:

<img width="253" alt="Screenshot 2025-05-28 at 10 44 46 AM" src="https://github.com/user-attachments/assets/73a534f6-a513-4947-8198-43a76402c700" />

I did not touch the `Recents` tree.