### PR TITLE
Fix Servers tree action buttons for servers defined in a workspace folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
         },
         {
           "command": "intersystems-community.servermanager.openPortalExplorerExternal",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
           "group": "1_builtin@10"
         }
       ],
@@ -571,33 +571,33 @@
         {
           "command": "intersystems-community.servermanager.editNamespace",
           "alt": "intersystems-community.servermanager.editNamespaceWebAppFiles",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/ && !(viewItem =~ /\\/wsFolder\\//)",
           "group": "inline@10"
         },
         {
           "command": "intersystems-community.servermanager.viewNamespace",
           "alt": "intersystems-community.servermanager.viewNamespaceWebAppFiles",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/ && !(viewItem =~ /\\/wsFolder\\//)",
           "group": "inline@20"
         },
         {
           "command": "intersystems-community.servermanager.editProject",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /project$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /project$/ && !(viewItem =~ /\\/wsFolder\\//)",
           "group": "inline@10"
         },
         {
           "command": "intersystems-community.servermanager.viewProject",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /project$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /project$/ && !(viewItem =~ /\\/wsFolder\\//)",
           "group": "inline@20"
         },
         {
           "command": "intersystems-community.servermanager.editWebApp",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /webapp$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /webapp$/ && !(viewItem =~ /\\/wsFolder\\//)",
           "group": "inline@10"
         },
         {
           "command": "intersystems-community.servermanager.viewWebApp",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /webapp$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /webapp$/ && !(viewItem =~ /\\/wsFolder\\//)",
           "group": "inline@20"
         },
         {

--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
         },
         {
           "command": "intersystems-community.servermanager.openPortalExplorerExternal",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace/",
           "group": "1_builtin@10"
         }
       ],

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -168,7 +168,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		}),
 		vscode.commands.registerCommand(`${extensionId}.openPortalExternal`, (server?: ServerTreeItem) => {
 			if (server?.contextValue?.match(/\.server\./) && server.name) {
-				getPortalUriWithToken(BrowserTarget.EXTERNAL, server.name).then((uriWithToken) => {
+				getPortalUriWithToken(BrowserTarget.EXTERNAL, server.name, undefined, undefined, server?.params?.serverSummary?.scope).then((uriWithToken) => {
 					if (uriWithToken) {
 						vscode.env.openExternal(uriWithToken);
 					}
@@ -177,7 +177,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		}),
 		vscode.commands.registerCommand(`${extensionId}.openPortalTab`, (server?: ServerTreeItem) => {
 			if (server?.contextValue?.match(/\.server\./) && server.name) {
-				getPortalUriWithToken(BrowserTarget.SIMPLE, server.name).then((uriWithToken) => {
+				getPortalUriWithToken(BrowserTarget.SIMPLE, server.name, undefined, undefined, server?.params?.serverSummary?.scope).then((uriWithToken) => {
 					if (uriWithToken) {
 						//
 						// It is essential to pass skipEncoding=true when converting the uri to a string,
@@ -193,7 +193,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				if (pathParts && pathParts.length === 4) {
 					const serverName = pathParts[1];
 					const namespace = pathParts[3];
-					getPortalUriWithToken(BrowserTarget.EXTERNAL, serverName, "/csp/sys/exp/%25CSP.UI.Portal.ClassList.zen", namespace).then((uriWithToken) => {
+					getPortalUriWithToken(BrowserTarget.EXTERNAL, serverName, "/csp/sys/exp/%25CSP.UI.Portal.ClassList.zen", namespace, namespaceTreeItem.parent?.parent?.params?.serverSummary?.scope).then((uriWithToken) => {
 						if (uriWithToken) {
 							vscode.env.openExternal(uriWithToken);
 						}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -548,7 +548,7 @@ export class NamespaceTreeItem extends SMTreeItem {
 			params: { serverName, serverSpec, serverApiVersion }
 		});
 		this.name = name;
-		this.contextValue = `${serverApiVersion.toString()}/${name === "%SYS" ? "sysnamespace" : "namespace"}${serverItemIsWsFolder(element?.parent?.parent) ? "wsFolder" : ""}`;
+		this.contextValue = `${serverApiVersion.toString()}${serverItemIsWsFolder(element?.parent?.parent) ? "/wsFolder" : ""}/${name === "%SYS" ? "sysnamespace" : "namespace"}`;
 		this.iconPath = new vscode.ThemeIcon("archive");
 	}
 }
@@ -650,7 +650,7 @@ export class ProjectTreeItem extends SMTreeItem {
 			tooltip: description
 		});
 		this.name = name;
-		this.contextValue = `${serverApiVersion.toString()}/project${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "wsFolder" : ""}`;
+		this.contextValue = `${serverApiVersion.toString()}${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "/wsFolder" : ""}/project`;
 		this.iconPath = new vscode.ThemeIcon('files');
 	}
 }
@@ -725,7 +725,7 @@ export class WebAppTreeItem extends SMTreeItem {
 			id
 		});
 		this.name = name;
-		this.contextValue = `${serverApiVersion.toString()}/webapp${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "wsFolder" : ""}`;
+		this.contextValue = `${serverApiVersion.toString()}${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "/wsFolder" : ""}/webapp`;
 		this.iconPath = new vscode.ThemeIcon('file-code');
 	}
 }

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -522,6 +522,11 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 	return children;
 }
 
+/** Returns `true` if `server` is a tree item representing a server defined at the workspace folder level */
+function serverItemIsWsFolder(server?: SMTreeItem): boolean {
+	return typeof server?.label == "string" && server.label.includes("(") && server.label.endsWith(")");
+}
+
 // tslint:disable-next-line: max-classes-per-file
 export class NamespaceTreeItem extends SMTreeItem {
 	public readonly name: string;
@@ -543,7 +548,7 @@ export class NamespaceTreeItem extends SMTreeItem {
 			params: { serverName, serverSpec, serverApiVersion }
 		});
 		this.name = name;
-		this.contextValue = `${serverApiVersion.toString()}/${name === "%SYS" ? "sysnamespace" : "namespace"}`;
+		this.contextValue = `${serverApiVersion.toString()}/${name === "%SYS" ? "sysnamespace" : "namespace"}${serverItemIsWsFolder(element?.parent?.parent) ? "wsFolder" : ""}`;
 		this.iconPath = new vscode.ThemeIcon("archive");
 	}
 }
@@ -645,7 +650,7 @@ export class ProjectTreeItem extends SMTreeItem {
 			tooltip: description
 		});
 		this.name = name;
-		this.contextValue = serverApiVersion.toString() + '/project';
+		this.contextValue = `${serverApiVersion.toString()}/project${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "wsFolder" : ""}`;
 		this.iconPath = new vscode.ThemeIcon('files');
 	}
 }
@@ -720,7 +725,7 @@ export class WebAppTreeItem extends SMTreeItem {
 			id
 		});
 		this.name = name;
-		this.contextValue = serverApiVersion.toString() + '/webapp';
+		this.contextValue = `${serverApiVersion.toString()}/webapp${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "wsFolder" : ""}`;
 		this.iconPath = new vscode.ThemeIcon('file-code');
 	}
 }


### PR DESCRIPTION
- Fixes #284 
-  Hide the view and edit code commands. It doesn't make sense to allow the creation of server-side workspace folders for servers that are defined within a workspace folder. The created server-side folders will not work.
- Fix the SMP commands.
