### PR TITLE
Prepare 3.12.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.12.2 (14-Apr-2026)
+* Update dependencies (#324).
+
 ## 3.12.1 (08-Apr-2026)
 * Update dependencies (#316, #317, #318, #319, #321).
 


### PR DESCRIPTION
I believe this is worth doing because the CVE in axios was critical-level 