### PR TITLE
OAuth2 VSCode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "servermanager",
-  "version": "3.12.3-SNAPSHOT",
+  "version": "3.12.4-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "servermanager",
-      "version": "3.12.3-SNAPSHOT",
+      "version": "3.12.4-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "node-cmd": "^5.0.0"
       },
       "devDependencies": {
-        "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.1",
+        "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.2",
         "@types/glob": "^7.1.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^20.14.0",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@intersystems-community/intersystems-servermanager": {
-      "version": "3.10.3-beta.1",
-      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.10.3-beta.1.tgz",
-      "integrity": "sha512-VMtooRF8NisZ8HipF/ISBVKXIxwxf25WxZ06F1kO9VNl+VKOiCvaY5x+A/3xI5Urc8zZmO0FjGXkaN445wM8Mg==",
+      "version": "3.10.3-beta.2",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.10.3-beta.2.tgz",
+      "integrity": "sha512-5vHgOd3ybERwzwIRQQzQkfh6RbV3o3FBxFwmVJXnsCLrFhwuz0rjtx/HIXN/d/+i1in6d6E4tI2FzHZ1UHeupQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "node-cmd": "^5.0.0"
       },
       "devDependencies": {
-        "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.2",
+        "@intersystems-community/intersystems-servermanager": "^3.14.0",
         "@types/glob": "^7.1.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^20.14.0",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@intersystems-community/intersystems-servermanager": {
-      "version": "3.10.3-beta.2",
-      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.10.3-beta.2.tgz",
-      "integrity": "sha512-5vHgOd3ybERwzwIRQQzQkfh6RbV3o3FBxFwmVJXnsCLrFhwuz0rjtx/HIXN/d/+i1in6d6E4tI2FzHZ1UHeupQ==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.14.0.tgz",
+      "integrity": "sha512-VKitwu5OTCHUT5ABs13/pldNLn4rdjfVBSM0gKnEfR+pPHBTaTgtCARoqiPqGIkLghHl2LToFunCRlTdQhDV+A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "node-cmd": "^5.0.0"
       },
       "devDependencies": {
-        "@intersystems-community/intersystems-servermanager": "^3.10.2",
+        "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.1",
         "@types/glob": "^7.1.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^20.14.0",
@@ -68,10 +68,11 @@
       }
     },
     "node_modules/@intersystems-community/intersystems-servermanager": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.10.2.tgz",
-      "integrity": "sha512-gwXxtvh+22MbCg3ZS8+evMCOuMvoDmApeYIghhFe3+NePIHhEC0na/UxeoA65xe4Rc97CJ+B2bCca/UF6iDI1A==",
-      "dev": true
+      "version": "3.10.3-beta.1",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.10.3-beta.1.tgz",
+      "integrity": "sha512-VMtooRF8NisZ8HipF/ISBVKXIxwxf25WxZ06F1kO9VNl+VKOiCvaY5x+A/3xI5Urc8zZmO0FjGXkaN445wM8Mg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -241,15 +241,6 @@
                         "description": "OAuth2 client ID for this application.",
                         "minLength": 1
                       },
-                      "audience": {
-                        "type": "string",
-                        "description": "API identifier (audience) registered with your identity provider. Typically the IRIS server's base URL.",
-                        "pattern": "^https?://",
-                        "examples": [
-                          "http://localhost:52773/",
-                          "https://iris-server.example.com/"
-                        ]
-                      },
                       "scopes": {
                         "type": "array",
                         "description": "Optional additional scopes to request beyond 'openid profile email'.",
@@ -261,8 +252,7 @@
                     },
                     "required": [
                       "authority",
-                      "clientId",
-                      "audience"
+                      "clientId"
                     ],
                     "additionalProperties": false
                   }

--- a/package.json
+++ b/package.json
@@ -209,6 +209,62 @@
                   "description": {
                     "type": "string",
                     "description": "Optional description of the server."
+                  },
+                  "authMethod": {
+                    "type": "string",
+                    "description": "Authentication method to use when connecting to this server.",
+                    "enum": [
+                      "password",
+                      "oauth2"
+                    ],
+                    "enumDescriptions": [
+                      "Username and password authentication (default)",
+                      "OAuth2/OpenID Connect authentication (e.g., Auth0, Keycloak)"
+                    ],
+                    "default": "password"
+                  },
+                  "oauth2": {
+                    "type": "object",
+                    "description": "OAuth2/OpenID Connect configuration. Required when authMethod is 'oauth2'.",
+                    "properties": {
+                      "authority": {
+                        "type": "string",
+                        "description": "OAuth2 authority URL (issuer) from your identity provider.",
+                        "pattern": "^https?://",
+                        "examples": [
+                          "https://your-domain.auth0.com",
+                          "https://login.microsoftonline.com/YOUR-TENANT-ID/v2.0"
+                        ]
+                      },
+                      "clientId": {
+                        "type": "string",
+                        "description": "OAuth2 client ID for this application.",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "description": "API identifier (audience) registered with your identity provider. Typically the IRIS server's base URL.",
+                        "pattern": "^https?://",
+                        "examples": [
+                          "http://localhost:52773/",
+                          "https://iris-server.example.com/"
+                        ]
+                      },
+                      "scopes": {
+                        "type": "array",
+                        "description": "Optional additional scopes to request beyond 'openid profile email'.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      }
+                    },
+                    "required": [
+                      "authority",
+                      "clientId",
+                      "audience"
+                    ],
+                    "additionalProperties": false
                   }
                 },
                 "required": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-cmd": "^5.0.0"
   },
   "devDependencies": {
-    "@intersystems-community/intersystems-servermanager": "^3.10.2",
+    "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.1",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "servermanager",
   "displayName": "InterSystems Server Manager",
-  "version": "3.12.4-SNAPSHOT",
+  "version": "3.14.0",
   "publisher": "intersystems-community",
   "description": "Define connections to InterSystems servers. Browse and manage those servers.",
   "repository": {
@@ -53,7 +53,7 @@
     "node-cmd": "^5.0.0"
   },
   "devDependencies": {
-    "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.2",
+    "@intersystems-community/intersystems-servermanager": "^3.14.0",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.14.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-cmd": "^5.0.0"
   },
   "devDependencies": {
-    "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.1",
+    "@intersystems-community/intersystems-servermanager": "^3.10.3-beta.2",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "servermanager",
   "displayName": "InterSystems Server Manager",
-  "version": "3.14.0",
+  "version": "3.12.4-SNAPSHOT",
   "publisher": "intersystems-community",
   "description": "Define connections to InterSystems servers. Browse and manage those servers.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -210,19 +210,6 @@
                     "type": "string",
                     "description": "Optional description of the server."
                   },
-                  "authMethod": {
-                    "type": "string",
-                    "description": "Authentication method to use when connecting to this server.",
-                    "enum": [
-                      "password",
-                      "oauth2"
-                    ],
-                    "enumDescriptions": [
-                      "Username and password authentication (default)",
-                      "OAuth2/OpenID Connect authentication (e.g., Auth0, Keycloak)"
-                    ],
-                    "default": "password"
-                  },
                   "oauth2": {
                     "type": "object",
                     "description": "OAuth2/OpenID Connect configuration. Required when authMethod is 'oauth2'.",

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -27,7 +27,6 @@ export async function addServer(
 		.then(
 			async (name): Promise<string | undefined> => {
 				if (name === undefined) return;
-
 				let description = await vscode.window.showInputBox({
 					ignoreFocusOut: true,
 					title: "Optionally enter a description",
@@ -80,7 +79,7 @@ export async function addServer(
 					if (!clientId) return;
 					authDetails = { username: "OAuth2User", oauth2: { authority, clientId } };
 				} else {
-					const username = await vscode.window.showInputBox({
+					let username = await vscode.window.showInputBox({
 						ignoreFocusOut: true,
 						title:
 							"Enter the username",
@@ -88,7 +87,8 @@ export async function addServer(
 							"Leave empty to be prompted when connecting.",
 					});
 					if (username === undefined) return;
-					authDetails = { username: username.trim() };
+					username = username.trim();
+					authDetails = { username };
 				}
 				const scheme = await new Promise<string | undefined>((resolve) => {
 					let result: string;

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -74,9 +74,9 @@ export async function addServer(
 				let authDetails: Pick<IServerSetting, "username" | "oauth2">;
 				if (authMethod === undefined) return;
 				if (authMethod === "oauth2") {
-					const authority = await promptOAuth2Authority(name);
+					const authority = (await promptOAuth2Authority(name))?.trim();
 					if (!authority) return;
-					const clientId = await promptOAuth2ClientId(name);
+					const clientId = (await promptOAuth2ClientId(name))?.trim();
 					if (!clientId) return;
 					authDetails = { oauth2: { authority, clientId } };
 				} else {

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { promptAuthMethod, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
 import { getServerNames } from "./getServerNames";
+import { IServerSetting } from "../serverSetting";
 
 export async function addServer(
 	scope?: vscode.ConfigurationScope,
@@ -70,7 +71,7 @@ export async function addServer(
 					pathPrefix = pathPrefix.slice(0, -1);
 				}
 				const authMethod = await promptAuthMethod();
-				let authDetails: { username?: string; oauth2?: { authority: string; clientId: string; } };
+				let authDetails: Pick<IServerSetting, "username" | "oauth2">;
 				if (authMethod === undefined) return;
 				if (authMethod === "oauth2") {
 					const authority = await promptOAuth2Authority(name);

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { IJSONServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { promptAuthMethod, promptOAuth2Audience, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
 import { getServerNames } from "./getServerNames";
 
 export async function addServer(
@@ -90,6 +91,34 @@ export async function addServer(
 									if (usernameTrimmed !== "") {
 										spec.username = usernameTrimmed;
 									}
+
+									// Prompt for authentication method
+									const authMethod = await promptAuthMethod();
+									if (typeof authMethod === "undefined") {
+										return undefined;
+									}
+									if (authMethod === "oauth2") {
+										(spec as any).authMethod = "oauth2";
+
+										const authority = await promptOAuth2Authority(name);
+										if (!authority) {
+											return undefined;
+										}
+
+										const clientId = await promptOAuth2ClientId(name);
+										if (!clientId) {
+											return undefined;
+										}
+
+										const defaultAudience = `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`;
+										const audience = await promptOAuth2Audience(name, defaultAudience);
+										if (!audience) {
+											return undefined;
+										}
+
+										(spec as any).oauth2 = { authority, clientId, audience };
+									}
+
 									const scheme = await new Promise<string | undefined>((resolve) => {
 										let result: string;
 										const quickPick = vscode.window.createQuickPick();

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { IJSONServerSpec } from "@intersystems-community/intersystems-servermanager";
-import { promptAuthMethod, promptOAuth2Audience, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
+import { promptAuthMethod, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
 import { getServerNames } from "./getServerNames";
 
 export async function addServer(
@@ -28,150 +28,128 @@ export async function addServer(
 		})
 		.then(
 			async (name): Promise<string | undefined> => {
-				if (name) {
-					const description = await vscode.window.showInputBox({
+				if (name === undefined) return;
+
+				let description = await vscode.window.showInputBox({
+					ignoreFocusOut: true,
+					title: "Optionally enter a description",
+				});
+				if (description === undefined) return;
+				description = description.trim();
+				if (description) spec.description = description;
+
+				const host = await vscode.window.showInputBox({
+					ignoreFocusOut: true,
+					title: "Enter the hostname or IP address of the web server",
+					validateInput: (value) => {
+						return value.trim().length ? undefined : "Required";
+					},
+				});
+				if (host === undefined) return;
+				spec.webServer.host = host.trim();
+
+				const portString = await vscode.window.showInputBox({
+					ignoreFocusOut: true,
+					title: "Enter the port of the web server",
+					validateInput: (value) => {
+						const port = +value;
+						return value.match(/\d+/) &&
+							port.toString() === value &&
+							port > 0 &&
+							port < 65536
+							? undefined
+							: "Required, 1-65535";
+					},
+				});
+				if (portString === undefined) return;
+				spec.webServer.port = +portString;
+
+				let pathPrefix = await vscode.window.showInputBox({
+					ignoreFocusOut: true,
+					title:
+						"Optionally enter the path prefix of the instance",
+				});
+				if (pathPrefix === undefined) return;
+				pathPrefix = pathPrefix.trim();
+				if (!pathPrefix.startsWith("/")) {
+					pathPrefix = "/" + pathPrefix;
+				}
+				if (pathPrefix.endsWith("/")) {
+					pathPrefix = pathPrefix.slice(0, -1);
+				}
+				spec.webServer.pathPrefix = pathPrefix;
+
+				const authMethod = await promptAuthMethod();
+				if (authMethod === undefined) return;
+				if (authMethod === "oauth2") {
+					(spec as any).authMethod = "oauth2";
+					const authority = await promptOAuth2Authority(name);
+					if (!authority) return;
+					const clientId = await promptOAuth2ClientId(name);
+					if (!clientId) return;
+					(spec as any).oauth2 = { authority, clientId };
+				} else {
+					const username = await vscode.window.showInputBox({
 						ignoreFocusOut: true,
-						title: "Optionally enter a description",
+						title:
+							"Enter the username",
+						prompt:
+							"Leave empty to be prompted when connecting.",
 					});
-					if (typeof description !== "undefined") {
-						if (description) {
-							spec.description = description.trim();
-						}
-						const host = await vscode.window.showInputBox({
-							ignoreFocusOut: true,
-							title: "Enter the hostname or IP address of the web server",
-							validateInput: (value) => {
-								return value.trim().length ? undefined : "Required";
-							},
-						});
-						if (host) {
-							spec.webServer.host = host.trim();
-							const portString = await vscode.window.showInputBox({
-								ignoreFocusOut: true,
-								title: "Enter the port of the web server",
-								validateInput: (value) => {
-									const port = +value;
-									return value.match(/\d+/) &&
-										port.toString() === value &&
-										port > 0 &&
-										port < 65536
-										? undefined
-										: "Required, 1-65535";
-								},
-							});
-							if (portString) {
-								spec.webServer.port = +portString;
-								const prefix = await vscode.window.showInputBox({
-									ignoreFocusOut: true,
-									title:
-										"Optionally enter the path prefix of the instance",
-								});
-								if (typeof prefix !== "undefined") {
-									if (prefix) {
-										var pathPrefix = prefix.trim();
-										if (!pathPrefix.startsWith("/")) {
-											pathPrefix = "/" + pathPrefix;
-										}
-										if (pathPrefix.endsWith("/")) {
-											pathPrefix = pathPrefix.slice(0, -1);
-										}
-										spec.webServer.pathPrefix = pathPrefix;
-									}
-								}
+					if (username === undefined) return;
+					if (username) spec.username = username;
+				}
 
-								const username = await vscode.window.showInputBox({
-									ignoreFocusOut: true,
-									title:
-										"Enter the username",
-									prompt:
-										"Leave empty to be prompted when connecting.",
-								});
-								if (typeof username !== "undefined") {
-									const usernameTrimmed = username.trim();
-									if (usernameTrimmed !== "") {
-										spec.username = usernameTrimmed;
-									}
+				const scheme = await new Promise<string | undefined>((resolve) => {
+					let result: string;
+					const quickPick = vscode.window.createQuickPick();
+					quickPick.title = "Confirm the connection type, then the definition will be stored in your User Settings. 'Escape' to cancel.";
+					quickPick.ignoreFocusOut = true;
+					quickPick.items = [{ label: "http" }, { label: "https" }];
+					quickPick.activeItems = [quickPick.items[spec.webServer.port == 443 ? 1 : 0]];
+					quickPick.onDidChangeSelection((items) => {
+						result = items[0].label;
+					});
+					quickPick.onDidAccept(() => {
+						resolve(result);
+						quickPick.hide();
+						quickPick.dispose();
+					});
+					quickPick.onDidHide(() => {
+						resolve(undefined);
+						quickPick.dispose();
+					});
+					quickPick.show();
+				});
+				if (scheme === undefined) return;
+				spec.webServer.scheme = scheme;
 
-									// Prompt for authentication method
-									const authMethod = await promptAuthMethod();
-									if (typeof authMethod === "undefined") {
-										return undefined;
-									}
-									if (authMethod === "oauth2") {
-										(spec as any).authMethod = "oauth2";
-
-										const authority = await promptOAuth2Authority(name);
-										if (!authority) {
-											return undefined;
-										}
-
-										const clientId = await promptOAuth2ClientId(name);
-										if (!clientId) {
-											return undefined;
-										}
-
-										const defaultAudience = `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`;
-										const audience = await promptOAuth2Audience(name, defaultAudience);
-										if (!audience) {
-											return undefined;
-										}
-
-										(spec as any).oauth2 = { authority, clientId, audience };
-									}
-
-									const scheme = await new Promise<string | undefined>((resolve) => {
-										let result: string;
-										const quickPick = vscode.window.createQuickPick();
-										quickPick.title = "Confirm the connection type, then the definition will be stored in your User Settings. 'Escape' to cancel.";
-										quickPick.ignoreFocusOut = true;
-										quickPick.items = [{ label: "http" }, { label: "https" }];
-										quickPick.activeItems = [quickPick.items[spec.webServer.port == 443 ? 1 : 0]];
-										quickPick.onDidChangeSelection((items) => {
-											result = items[0].label;
-										});
-										quickPick.onDidAccept(() => {
-											resolve(result);
-											quickPick.hide();
-											quickPick.dispose();
-										});
-										quickPick.onDidHide(() => {
-											resolve(undefined);
-											quickPick.dispose();
-										});
-										quickPick.show();
-									});
-									if (scheme) {
-										spec.webServer.scheme = scheme;
-										const levelStr =
-											target == vscode.ConfigurationTarget.WorkspaceFolder ? "workspace-folder" :
-												target == vscode.ConfigurationTarget.Workspace ? "workspace" :
-													"user";
-										try {
-											const config = vscode.workspace.getConfiguration(
-												"intersystems",
-												scope,
-											);
-											const serversInspection = config.inspect("servers");
-											const servers = (
-												target == vscode.ConfigurationTarget.WorkspaceFolder ? serversInspection?.workspaceFolderValue :
-													target == vscode.ConfigurationTarget.Workspace ? serversInspection?.workspaceValue :
-														serversInspection?.globalValue
-											) ?? {};
-											servers[name] = spec;
-											await config.update("servers", servers, target);
-											vscode.window.showInformationMessage(`Server '${name}' stored in ${levelStr}-level settings.`);
-											return name;
-										} catch (error) {
-											vscode.window.showErrorMessage(
-												`Failed to store server '${name}' definition. Does your ${levelStr}-level settings file contain a JSON syntax error?`,
-											);
-											return undefined;
-										}
-									}
-								}
-							}
-						}
-					}
+				const levelStr =
+					target == vscode.ConfigurationTarget.WorkspaceFolder
+						? "workspace-folder"
+						: target == vscode.ConfigurationTarget.Workspace
+							? "workspace"
+							: "user";
+				try {
+					const config = vscode.workspace.getConfiguration(
+						"intersystems",
+						scope,
+					);
+					const serversInspection = config.inspect("servers");
+					const servers = (
+						target == vscode.ConfigurationTarget.WorkspaceFolder ? serversInspection?.workspaceFolderValue :
+							target == vscode.ConfigurationTarget.Workspace ? serversInspection?.workspaceValue :
+								serversInspection?.globalValue
+					) ?? {};
+					servers[name] = spec;
+					await config.update("servers", servers, target);
+					vscode.window.showInformationMessage(`Server '${name}' stored in ${levelStr}-level settings.`);
+					return name;
+				} catch (error) {
+					vscode.window.showErrorMessage(
+						`Failed to store server '${name}' definition. Does your ${levelStr}-level settings file contain a JSON syntax error?`,
+					);
+					return;
 				}
 			},
 		);

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { IJSONServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { promptAuthMethod, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
 import { getServerNames } from "./getServerNames";
 
@@ -8,7 +7,6 @@ export async function addServer(
 	target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global
 ): Promise<string | undefined> {
 	const serverNames = getServerNames(scope);
-	const spec: IJSONServerSpec = { webServer: { scheme: "", host: "", port: 0 } };
 	return await vscode.window
 		.showInputBox({
 			ignoreFocusOut: true,
@@ -36,9 +34,7 @@ export async function addServer(
 				});
 				if (description === undefined) return;
 				description = description.trim();
-				if (description) spec.description = description;
-
-				const host = await vscode.window.showInputBox({
+				let host = await vscode.window.showInputBox({
 					ignoreFocusOut: true,
 					title: "Enter the hostname or IP address of the web server",
 					validateInput: (value) => {
@@ -46,9 +42,8 @@ export async function addServer(
 					},
 				});
 				if (host === undefined) return;
-				spec.webServer.host = host.trim();
-
-				const portString = await vscode.window.showInputBox({
+				host = host.trim();
+				const port = await vscode.window.showInputBox({
 					ignoreFocusOut: true,
 					title: "Enter the port of the web server",
 					validateInput: (value) => {
@@ -61,9 +56,7 @@ export async function addServer(
 							: "Required, 1-65535";
 					},
 				});
-				if (portString === undefined) return;
-				spec.webServer.port = +portString;
-
+				if (port === undefined) return;
 				let pathPrefix = await vscode.window.showInputBox({
 					ignoreFocusOut: true,
 					title:
@@ -77,17 +70,15 @@ export async function addServer(
 				if (pathPrefix.endsWith("/")) {
 					pathPrefix = pathPrefix.slice(0, -1);
 				}
-				spec.webServer.pathPrefix = pathPrefix;
-
 				const authMethod = await promptAuthMethod();
+				let authDetails: { username: string; oauth2?: { authority: string; clientId: string; } };
 				if (authMethod === undefined) return;
 				if (authMethod === "oauth2") {
-					(spec as any).authMethod = "oauth2";
 					const authority = await promptOAuth2Authority(name);
 					if (!authority) return;
 					const clientId = await promptOAuth2ClientId(name);
 					if (!clientId) return;
-					(spec as any).oauth2 = { authority, clientId };
+					authDetails = { username: "OAuth2User", oauth2: { authority, clientId } };
 				} else {
 					const username = await vscode.window.showInputBox({
 						ignoreFocusOut: true,
@@ -97,16 +88,15 @@ export async function addServer(
 							"Leave empty to be prompted when connecting.",
 					});
 					if (username === undefined) return;
-					if (username) spec.username = username;
+					authDetails = { username: username.trim() };
 				}
-
 				const scheme = await new Promise<string | undefined>((resolve) => {
 					let result: string;
 					const quickPick = vscode.window.createQuickPick();
 					quickPick.title = "Confirm the connection type, then the definition will be stored in your User Settings. 'Escape' to cancel.";
 					quickPick.ignoreFocusOut = true;
 					quickPick.items = [{ label: "http" }, { label: "https" }];
-					quickPick.activeItems = [quickPick.items[spec.webServer.port == 443 ? 1 : 0]];
+					quickPick.activeItems = [quickPick.items[port === "443" ? 1 : 0]];
 					quickPick.onDidChangeSelection((items) => {
 						result = items[0].label;
 					});
@@ -122,8 +112,6 @@ export async function addServer(
 					quickPick.show();
 				});
 				if (scheme === undefined) return;
-				spec.webServer.scheme = scheme;
-
 				const levelStr =
 					target == vscode.ConfigurationTarget.WorkspaceFolder
 						? "workspace-folder"
@@ -141,7 +129,12 @@ export async function addServer(
 							target == vscode.ConfigurationTarget.Workspace ? serversInspection?.workspaceValue :
 								serversInspection?.globalValue
 					) ?? {};
-					servers[name] = spec;
+					servers[name] = {
+						webServer: { scheme, host, port: +port, pathPrefix },
+						...(description ? { description } : {}),
+						authMethod,
+						...authDetails,
+					};
 					await config.update("servers", servers, target);
 					vscode.window.showInformationMessage(`Server '${name}' stored in ${levelStr}-level settings.`);
 					return name;

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -70,14 +70,14 @@ export async function addServer(
 					pathPrefix = pathPrefix.slice(0, -1);
 				}
 				const authMethod = await promptAuthMethod();
-				let authDetails: { username: string; oauth2?: { authority: string; clientId: string; } };
+				let authDetails: { username?: string; oauth2?: { authority: string; clientId: string; } };
 				if (authMethod === undefined) return;
 				if (authMethod === "oauth2") {
 					const authority = await promptOAuth2Authority(name);
 					if (!authority) return;
 					const clientId = await promptOAuth2ClientId(name);
 					if (!clientId) return;
-					authDetails = { username: "OAuth2User", oauth2: { authority, clientId } };
+					authDetails = { oauth2: { authority, clientId } };
 				} else {
 					let username = await vscode.window.showInputBox({
 						ignoreFocusOut: true,
@@ -132,7 +132,6 @@ export async function addServer(
 					servers[name] = {
 						webServer: { scheme, host, port: +port, pathPrefix },
 						...(description ? { description } : {}),
-						authMethod,
 						...authDetails,
 					};
 					await config.update("servers", servers, target);

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -71,7 +71,7 @@ export async function addServer(
 	const authMethod = (await vscode.window.showQuickPick(
 		[
 			{ label: "Basic", description: "Username/password" },
-			{ label: "OAuth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
+			{ label: "OAuth2", description: "OAuth2/OpenID Connect" },
 			{ label: "Unauthenticated", description: "Not recommended. Only use when your server is configured to allow it." },
 		] as const,
 		{ ignoreFocusOut: true, title: "Select the authentication method" },

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { promptAuthMethod, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
+import { promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
 import { IServerSetting } from "../serverSetting";
 import { getServerNames } from "./getServerNames";
 
@@ -67,7 +67,13 @@ export async function addServer(
 	if (pathPrefix.endsWith("/")) {
 		pathPrefix = pathPrefix.slice(0, -1);
 	}
-	const authMethod = await promptAuthMethod();
+	const authMethod = (await vscode.window.showQuickPick(
+		[
+			{ label: "password", description: "Classic username/password authentication" },
+			{ label: "oauth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
+		],
+		{ ignoreFocusOut: true, title: "Select the authentication method" },
+	))?.label;
 	if (authMethod === undefined) { return; }
 	let authDetails: Pick<IServerSetting, "username" | "oauth2">;
 	if (authMethod === "oauth2") {

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -84,7 +84,7 @@ export async function addServer(
 		const clientId = (await promptOAuth2ClientId(name))?.trim();
 		if (!clientId) { return; }
 		authDetails = { oauth2: { authority, clientId } };
-	} else if (authMethod === "Basic Auth") {
+	} else if (authMethod === "Basic") {
 		let username = await vscode.window.showInputBox({
 			ignoreFocusOut: true,
 			title:

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -89,7 +89,11 @@ export async function addServer(
 					});
 					if (username === undefined) return;
 					username = username.trim();
-					authDetails = { username };
+					if (username) {
+						authDetails = { username };
+					} else {
+						authDetails = {}
+					}
 				}
 				const scheme = await new Promise<string | undefined>((resolve) => {
 					let result: string;

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -72,7 +72,7 @@ export async function addServer(
 		[
 			{ label: "Basic", description: "Username/password" },
 			{ label: "OAuth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
-			{ label: "Unauthenticated", description: "Prompt for username and password only when needed" },
+			{ label: "Unauthenticated", description: "Not recommended. Only use when your server is configured to allow it." },
 		] as const,
 		{ ignoreFocusOut: true, title: "Select the authentication method" },
 	))?.label;

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -8,146 +8,141 @@ export async function addServer(
 	target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global
 ): Promise<string | undefined> {
 	const serverNames = getServerNames(scope);
-	return await vscode.window
-		.showInputBox({
+	const name = await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: "Enter name of new server definition",
+		validateInput: (value) => {
+			if (value === "") {
+				return "Required";
+			}
+			if (serverNames.filter((server) => server.name === value).length) {
+				return "Name already exists";
+			}
+			if (!value.match(/^[a-z0-9-_~]+$/)) {
+				return "Can only contain a-z, 0-9 and punctuation -_~";
+			}
+			return null;
+		},
+	});
+	if (name === undefined) return;
+	let description = await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: "Optionally enter a description",
+	});
+	if (description === undefined) return;
+	description = description.trim();
+	let host = await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: "Enter the hostname or IP address of the web server",
+		validateInput: (value) => {
+			return value.trim().length ? undefined : "Required";
+		},
+	});
+	if (host === undefined) return;
+	host = host.trim();
+	const port = await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: "Enter the port of the web server",
+		validateInput: (value) => {
+			const port = +value;
+			return value.match(/\d+/) &&
+				port.toString() === value &&
+				port > 0 &&
+				port < 65536
+				? undefined
+				: "Required, 1-65535";
+		},
+	});
+	if (port === undefined) return;
+	let pathPrefix = await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title:
+			"Optionally enter the path prefix of the instance",
+	});
+	if (pathPrefix === undefined) return;
+	pathPrefix = pathPrefix.trim();
+	if (!pathPrefix.startsWith("/")) {
+		pathPrefix = "/" + pathPrefix;
+	}
+	if (pathPrefix.endsWith("/")) {
+		pathPrefix = pathPrefix.slice(0, -1);
+	}
+	const authMethod = await promptAuthMethod();
+	if (authMethod === undefined) return;
+	let authDetails: Pick<IServerSetting, "username" | "oauth2">;
+	if (authMethod === "oauth2") {
+		const authority = (await promptOAuth2Authority(name))?.trim();
+		if (!authority) return;
+		const clientId = (await promptOAuth2ClientId(name))?.trim();
+		if (!clientId) return;
+		authDetails = { oauth2: { authority, clientId } };
+	} else {
+		let username = await vscode.window.showInputBox({
 			ignoreFocusOut: true,
-			title: "Enter name of new server definition",
-			validateInput: (value) => {
-				if (value === "") {
-					return "Required";
-				}
-				if (serverNames.filter((server) => server.name === value).length) {
-					return "Name already exists";
-				}
-				if (!value.match(/^[a-z0-9-_~]+$/)) {
-					return "Can only contain a-z, 0-9 and punctuation -_~";
-				}
-				return null;
-			},
-		})
-		.then(
-			async (name): Promise<string | undefined> => {
-				if (name === undefined) return;
-				let description = await vscode.window.showInputBox({
-					ignoreFocusOut: true,
-					title: "Optionally enter a description",
-				});
-				if (description === undefined) return;
-				description = description.trim();
-				let host = await vscode.window.showInputBox({
-					ignoreFocusOut: true,
-					title: "Enter the hostname or IP address of the web server",
-					validateInput: (value) => {
-						return value.trim().length ? undefined : "Required";
-					},
-				});
-				if (host === undefined) return;
-				host = host.trim();
-				const port = await vscode.window.showInputBox({
-					ignoreFocusOut: true,
-					title: "Enter the port of the web server",
-					validateInput: (value) => {
-						const port = +value;
-						return value.match(/\d+/) &&
-							port.toString() === value &&
-							port > 0 &&
-							port < 65536
-							? undefined
-							: "Required, 1-65535";
-					},
-				});
-				if (port === undefined) return;
-				let pathPrefix = await vscode.window.showInputBox({
-					ignoreFocusOut: true,
-					title:
-						"Optionally enter the path prefix of the instance",
-				});
-				if (pathPrefix === undefined) return;
-				pathPrefix = pathPrefix.trim();
-				if (!pathPrefix.startsWith("/")) {
-					pathPrefix = "/" + pathPrefix;
-				}
-				if (pathPrefix.endsWith("/")) {
-					pathPrefix = pathPrefix.slice(0, -1);
-				}
-				const authMethod = await promptAuthMethod();
-				let authDetails: Pick<IServerSetting, "username" | "oauth2">;
-				if (authMethod === undefined) return;
-				if (authMethod === "oauth2") {
-					const authority = (await promptOAuth2Authority(name))?.trim();
-					if (!authority) return;
-					const clientId = (await promptOAuth2ClientId(name))?.trim();
-					if (!clientId) return;
-					authDetails = { oauth2: { authority, clientId } };
-				} else {
-					let username = await vscode.window.showInputBox({
-						ignoreFocusOut: true,
-						title:
-							"Enter the username",
-						prompt:
-							"Leave empty to be prompted when connecting.",
-					});
-					if (username === undefined) return;
-					username = username.trim();
-					if (username) {
-						authDetails = { username };
-					} else {
-						authDetails = {}
-					}
-				}
-				const scheme = await new Promise<string | undefined>((resolve) => {
-					let result: string;
-					const quickPick = vscode.window.createQuickPick();
-					quickPick.title = "Confirm the connection type, then the definition will be stored in your User Settings. 'Escape' to cancel.";
-					quickPick.ignoreFocusOut = true;
-					quickPick.items = [{ label: "http" }, { label: "https" }];
-					quickPick.activeItems = [quickPick.items[port === "443" ? 1 : 0]];
-					quickPick.onDidChangeSelection((items) => {
-						result = items[0].label;
-					});
-					quickPick.onDidAccept(() => {
-						resolve(result);
-						quickPick.hide();
-						quickPick.dispose();
-					});
-					quickPick.onDidHide(() => {
-						resolve(undefined);
-						quickPick.dispose();
-					});
-					quickPick.show();
-				});
-				if (scheme === undefined) return;
-				const levelStr =
-					target == vscode.ConfigurationTarget.WorkspaceFolder
-						? "workspace-folder"
-						: target == vscode.ConfigurationTarget.Workspace
-							? "workspace"
-							: "user";
-				try {
-					const config = vscode.workspace.getConfiguration(
-						"intersystems",
-						scope,
-					);
-					const serversInspection = config.inspect("servers");
-					const servers = (
-						target == vscode.ConfigurationTarget.WorkspaceFolder ? serversInspection?.workspaceFolderValue :
-							target == vscode.ConfigurationTarget.Workspace ? serversInspection?.workspaceValue :
-								serversInspection?.globalValue
-					) ?? {};
-					servers[name] = {
-						webServer: { scheme, host, port: +port, pathPrefix },
-						...(description ? { description } : {}),
-						...authDetails,
-					};
-					await config.update("servers", servers, target);
-					vscode.window.showInformationMessage(`Server '${name}' stored in ${levelStr}-level settings.`);
-					return name;
-				} catch (error) {
-					vscode.window.showErrorMessage(
-						`Failed to store server '${name}' definition. Does your ${levelStr}-level settings file contain a JSON syntax error?`,
-					);
-					return;
-				}
-			},
+			title:
+				"Enter the username",
+			prompt:
+				"Leave empty to be prompted when connecting.",
+		});
+		if (username === undefined) return;
+		username = username.trim();
+		if (username) {
+			authDetails = { username };
+		} else {
+			authDetails = {}
+		}
+	}
+	const scheme = await new Promise<string | undefined>((resolve) => {
+		let result: string;
+		const quickPick = vscode.window.createQuickPick();
+		quickPick.title = "Confirm the connection type, then the definition will be stored in your User Settings. 'Escape' to cancel.";
+		quickPick.ignoreFocusOut = true;
+		quickPick.items = [{ label: "http" }, { label: "https" }];
+		quickPick.activeItems = [quickPick.items[port === "443" ? 1 : 0]];
+		quickPick.onDidChangeSelection((items) => {
+			result = items[0].label;
+		});
+		quickPick.onDidAccept(() => {
+			resolve(result);
+			quickPick.hide();
+			quickPick.dispose();
+		});
+		quickPick.onDidHide(() => {
+			resolve(undefined);
+			quickPick.dispose();
+		});
+		quickPick.show();
+	});
+	if (scheme === undefined) return;
+	const levelStr =
+		target == vscode.ConfigurationTarget.WorkspaceFolder
+			? "workspace-folder"
+			: target == vscode.ConfigurationTarget.Workspace
+				? "workspace"
+				: "user";
+	try {
+		const config = vscode.workspace.getConfiguration(
+			"intersystems",
+			scope,
 		);
+		const serversInspection = config.inspect("servers");
+		const servers = (
+			target == vscode.ConfigurationTarget.WorkspaceFolder ? serversInspection?.workspaceFolderValue :
+				target == vscode.ConfigurationTarget.Workspace ? serversInspection?.workspaceValue :
+					serversInspection?.globalValue
+		) ?? {};
+		servers[name] = {
+			webServer: { scheme, host, port: +port, pathPrefix },
+			...(description ? { description } : {}),
+			...authDetails,
+		};
+		await config.update("servers", servers, target);
+		vscode.window.showInformationMessage(`Server '${name}' stored in ${levelStr}-level settings.`);
+		return name;
+	} catch (error) {
+		vscode.window.showErrorMessage(
+			`Failed to store server '${name}' definition. Does your ${levelStr}-level settings file contain a JSON syntax error?`,
+		);
+		return;
+	}
 }

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -70,7 +70,7 @@ export async function addServer(
 	}
 	const authMethod = (await vscode.window.showQuickPick(
 		[
-			{ label: "Basic Auth", description: "Classic username/password authentication" },
+			{ label: "Basic", description: "Username/password" },
 			{ label: "OAuth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
 			{ label: "Unauthenticated", description: "Prompt for username and password only when needed" },
 		] as const,

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import { promptAuthMethod, promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
-import { getServerNames } from "./getServerNames";
 import { IServerSetting } from "../serverSetting";
+import { getServerNames } from "./getServerNames";
 
 export async function addServer(
 	scope?: vscode.ConfigurationScope,
-	target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global
+	target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global,
 ): Promise<string | undefined> {
 	const serverNames = getServerNames(scope);
 	const name = await vscode.window.showInputBox({
@@ -24,12 +24,12 @@ export async function addServer(
 			return null;
 		},
 	});
-	if (name === undefined) return;
+	if (name === undefined) { return; }
 	let description = await vscode.window.showInputBox({
 		ignoreFocusOut: true,
 		title: "Optionally enter a description",
 	});
-	if (description === undefined) return;
+	if (description === undefined) { return; }
 	description = description.trim();
 	let host = await vscode.window.showInputBox({
 		ignoreFocusOut: true,
@@ -38,7 +38,7 @@ export async function addServer(
 			return value.trim().length ? undefined : "Required";
 		},
 	});
-	if (host === undefined) return;
+	if (host === undefined) { return; }
 	host = host.trim();
 	const port = await vscode.window.showInputBox({
 		ignoreFocusOut: true,
@@ -53,13 +53,13 @@ export async function addServer(
 				: "Required, 1-65535";
 		},
 	});
-	if (port === undefined) return;
+	if (port === undefined) { return; }
 	let pathPrefix = await vscode.window.showInputBox({
 		ignoreFocusOut: true,
 		title:
 			"Optionally enter the path prefix of the instance",
 	});
-	if (pathPrefix === undefined) return;
+	if (pathPrefix === undefined) { return; }
 	pathPrefix = pathPrefix.trim();
 	if (!pathPrefix.startsWith("/")) {
 		pathPrefix = "/" + pathPrefix;
@@ -68,13 +68,13 @@ export async function addServer(
 		pathPrefix = pathPrefix.slice(0, -1);
 	}
 	const authMethod = await promptAuthMethod();
-	if (authMethod === undefined) return;
+	if (authMethod === undefined) { return; }
 	let authDetails: Pick<IServerSetting, "username" | "oauth2">;
 	if (authMethod === "oauth2") {
 		const authority = (await promptOAuth2Authority(name))?.trim();
-		if (!authority) return;
+		if (!authority) { return; }
 		const clientId = (await promptOAuth2ClientId(name))?.trim();
-		if (!clientId) return;
+		if (!clientId) { return; }
 		authDetails = { oauth2: { authority, clientId } };
 	} else {
 		let username = await vscode.window.showInputBox({
@@ -84,12 +84,12 @@ export async function addServer(
 			prompt:
 				"Leave empty to be prompted when connecting.",
 		});
-		if (username === undefined) return;
+		if (username === undefined) { return; }
 		username = username.trim();
 		if (username) {
 			authDetails = { username };
 		} else {
-			authDetails = {}
+			authDetails = {};
 		}
 	}
 	const scheme = await new Promise<string | undefined>((resolve) => {
@@ -113,7 +113,7 @@ export async function addServer(
 		});
 		quickPick.show();
 	});
-	if (scheme === undefined) return;
+	if (scheme === undefined) { return; }
 	const levelStr =
 		target == vscode.ConfigurationTarget.WorkspaceFolder
 			? "workspace-folder"

--- a/src/api/addServer.ts
+++ b/src/api/addServer.ts
@@ -3,6 +3,7 @@ import { promptOAuth2Authority, promptOAuth2ClientId } from "../oauth2Prompts";
 import { IServerSetting } from "../serverSetting";
 import { getServerNames } from "./getServerNames";
 
+
 export async function addServer(
 	scope?: vscode.ConfigurationScope,
 	target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global,
@@ -69,20 +70,21 @@ export async function addServer(
 	}
 	const authMethod = (await vscode.window.showQuickPick(
 		[
-			{ label: "password", description: "Classic username/password authentication" },
-			{ label: "oauth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
-		],
+			{ label: "Basic Auth", description: "Classic username/password authentication" },
+			{ label: "OAuth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
+			{ label: "Unauthenticated", description: "Prompt for username and password only when needed" },
+		] as const,
 		{ ignoreFocusOut: true, title: "Select the authentication method" },
 	))?.label;
 	if (authMethod === undefined) { return; }
 	let authDetails: Pick<IServerSetting, "username" | "oauth2">;
-	if (authMethod === "oauth2") {
+	if (authMethod === "OAuth2") {
 		const authority = (await promptOAuth2Authority(name))?.trim();
 		if (!authority) { return; }
 		const clientId = (await promptOAuth2ClientId(name))?.trim();
 		if (!clientId) { return; }
 		authDetails = { oauth2: { authority, clientId } };
-	} else {
+	} else if (authMethod === "Basic Auth") {
 		let username = await vscode.window.showInputBox({
 			ignoreFocusOut: true,
 			title:
@@ -92,11 +94,11 @@ export async function addServer(
 		});
 		if (username === undefined) { return; }
 		username = username.trim();
-		if (username) {
-			authDetails = { username };
-		} else {
-			authDetails = {};
-		}
+		authDetails = { username };
+	} else if (authMethod === "Unauthenticated") {
+		authDetails = {}
+	} else {
+		throw Error(`Unreachable! ${authMethod} must be either "Basic Auth", "OAuth2", or "Unauthenticated".`)
 	}
 	const scheme = await new Promise<string | undefined>((resolve) => {
 		let result: string;

--- a/src/api/getPortalUri.ts
+++ b/src/api/getPortalUri.ts
@@ -1,6 +1,6 @@
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import * as vscode from "vscode";
 import { Uri } from "vscode";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { extensionId } from "../commonActivate";
 
 export async function getPortalUri(

--- a/src/api/getServerNames.ts
+++ b/src/api/getServerNames.ts
@@ -1,10 +1,10 @@
-import * as vscode from "vscode";
 import { IServerName } from "@intersystems-community/intersystems-servermanager";
+import * as vscode from "vscode";
 import { serverDetail } from "./getServerSummary";
 
 export function getServerNames(scope?: vscode.ConfigurationScope, sorted?: boolean): IServerName[] {
 	const allNames: IServerName[] = [];
-	let names: IServerName[] = [];
+	const names: IServerName[] = [];
 	const servers = vscode.workspace.getConfiguration("intersystems", scope).get("servers");
 
 	if (typeof servers === "object" && servers) {
@@ -34,7 +34,7 @@ export function getServerNames(scope?: vscode.ConfigurationScope, sorted?: boole
 	}
 
 	// If requested, sort what we found
-	if (sorted) names.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+	if (sorted) { names.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0); }
 
 	// Append them
 	allNames.push(...names);

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { OBJECTSCRIPT_EXTENSIONID } from "../commonActivate";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 /**
  * Get a server specification.
@@ -14,8 +14,7 @@ export async function getServerSpec(
 	scope?: vscode.ConfigurationScope,
 ): Promise<IServerSpec | undefined> {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	let server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) || legacyEmbeddedServer(name);
-
+	let server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
 	// Unknown server
 	if (!server) {
 		const folder = vscode.workspace.workspaceFolders?.find(f => f.name === name);
@@ -69,8 +68,8 @@ export async function getServerSpec(
 
 	// When authentication provider is being used we should only have a password if it came from the deprecated
 	// property of the settings object. Otherwise return it as undefined.
-	if (!server.password) {
-		server.password = undefined;
+	if (!server["password"]) {
+		server["password"] = undefined;
 	}
 	return server;
 }

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
-import { IServerSetting } from "../serverSetting";
-import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
+import { AuthRelatedSetting, IServerSetting } from "../serverSetting";
+import { Authorization, OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
 /**
  * Get a server specification.
@@ -63,7 +63,7 @@ export async function getServerSpec(
 		};
 	}
 
-	const { oauth2, username, password, ...spec } = setting;
+	const { username, password, oauth2, ...spec } = setting;
 	spec.name = name;
 	spec.description = spec.description || "";
 	spec.webServer.scheme = spec.webServer.scheme || "http";
@@ -75,10 +75,15 @@ export async function getServerSpec(
 	}
 	return {
 		...spec,
-		auth: (oauth2 === undefined)
-			? new PasswordAuthorization(username, password)
-			: new OAuth2Authorization(oauth2)
+		auth: getAuthFromSetting({ username, password, oauth2 })
 	};
+}
+
+export function getAuthFromSetting(setting: AuthRelatedSetting): Authorization {
+	const { username, password, oauth2 } = setting;
+	return (oauth2 === undefined)
+		? new PasswordAuthorization(username, password)
+		: new OAuth2Authorization(oauth2)
 }
 
 /**

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -76,7 +76,7 @@ export async function getServerSpec(
 	return {
 		...spec,
 		auth: (oauth2 === undefined)
-			? new PasswordAuthorization(username || "", password)
+			? new PasswordAuthorization(username, password)
 			: new OAuth2Authorization(oauth2)
 	};
 }

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -14,7 +14,7 @@ export async function getServerSpec(
 	scope?: vscode.ConfigurationScope,
 ): Promise<IServerSpec | undefined> {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	let server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
+	const server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
 	// Unknown server
 	if (!server) {
 		const folder = vscode.workspace.workspaceFolders?.find(f => f.name === name);
@@ -47,7 +47,7 @@ export async function getServerSpec(
 				scheme: serverForUri.scheme,
 				host: serverForUri.host,
 				port: serverForUri.port,
-				pathPrefix: serverForUri.pathPrefix
+				pathPrefix: serverForUri.pathPrefix,
 			},
 			username: serverForUri.username,
 			password: serverForUri.password ? serverForUri.password : undefined,
@@ -64,7 +64,6 @@ export async function getServerSpec(
 		// Fall back to default if appropriate
 		server.superServer.host = server.superServer.host || server.webServer.host;
 	}
-
 
 	// When authentication provider is being used we should only have a password if it came from the deprecated
 	// property of the settings object. Otherwise return it as undefined.

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -58,7 +58,7 @@ export async function getServerSpec(
 				port: serverForUri.port,
 				pathPrefix: serverForUri.pathPrefix,
 			},
-			authorization: new PasswordAuthorization(serverForUri.username, serverForUri.password),
+			auth: new PasswordAuthorization(serverForUri.username, serverForUri.password),
 			description: `Server for workspace folder "${name}"`,
 		};
 	}
@@ -75,7 +75,7 @@ export async function getServerSpec(
 	}
 	return {
 		...spec,
-		authorization: (oauth2 === undefined)
+		auth: (oauth2 === undefined)
 			? new PasswordAuthorization(username || "", password)
 			: new OAuth2Authorization(oauth2)
 	};

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
-import { AuthRelatedSetting, IServerSetting } from "../serverSetting";
-import { Authorization, OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
+import { IServerSetting } from "../serverSetting";
+import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
 /**
  * Get a server specification.
@@ -75,15 +75,10 @@ export async function getServerSpec(
 	}
 	return {
 		...spec,
-		auth: getAuthFromSetting({ username, password, oauth2 })
+		auth: oauth2 === undefined
+			? new PasswordAuthorization(username, password)
+			: new OAuth2Authorization(oauth2)
 	};
-}
-
-export function getAuthFromSetting(setting: AuthRelatedSetting): Authorization {
-	const { username, password, oauth2 } = setting;
-	return (oauth2 === undefined)
-		? new PasswordAuthorization(username, password)
-		: new OAuth2Authorization(oauth2)
 }
 
 /**

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
-import { IServerSetting } from "../serverSetting";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerSetting } from "../serverSetting";
+import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
 /**
  * Get a server specification.
@@ -75,9 +75,9 @@ export async function getServerSpec(
 	}
 	return {
 		...spec,
-		authorization: (oauth2 !== undefined)
-			? new OAuth2Authorization(oauth2)
-			: new PasswordAuthorization(username || "", password),
+		authorization: (oauth2 === undefined)
+			? new PasswordAuthorization(username || "", password)
+			: new OAuth2Authorization(oauth2)
 	};
 }
 

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { OBJECTSCRIPT_EXTENSIONID } from "../commonActivate";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerSetting } from "../serverSetting";
 
 /**
  * Get a server specification.
@@ -9,12 +9,12 @@ import { IServerSpec } from "@intersystems-community/intersystems-servermanager"
  * @param scope The settings scope to use for the lookup.
  * @returns Server specification or undefined.
  */
-export async function getServerSpec(
+export async function getServerSetting(
 	name: string,
 	scope?: vscode.ConfigurationScope,
-): Promise<IServerSpec | undefined> {
+): Promise<IServerSetting | undefined> {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
+	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSetting | undefined || legacyEmbeddedServer(name);
 	// Unknown server
 	if (!server) {
 		const folder = vscode.workspace.workspaceFolders?.find(f => f.name === name);
@@ -80,7 +80,7 @@ export async function getServerSpec(
  * @param name The name.
  * @returns Server specification or undefined.
  */
-export function legacyEmbeddedServer(name: string): IServerSpec | undefined {
+export function legacyEmbeddedServer(name: string): IServerSetting | undefined {
 	return {
 		"default~iris": {
 			"name": "default~iris",

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
-import { OBJECTSCRIPT_EXTENSIONID } from "../commonActivate";
+import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 import { IServerSetting } from "../serverSetting";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 /**
  * Get a server specification.
@@ -9,14 +10,14 @@ import { IServerSetting } from "../serverSetting";
  * @param scope The settings scope to use for the lookup.
  * @returns Server specification or undefined.
  */
-export async function getServerSetting(
+export async function getServerSpec(
 	name: string,
 	scope?: vscode.ConfigurationScope,
-): Promise<IServerSetting | undefined> {
+): Promise<IServerSpec | undefined> {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSetting | undefined || legacyEmbeddedServer(name);
+	const setting = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSetting | undefined || legacyEmbeddedServer(name);
 	// Unknown server
-	if (!server) {
+	if (!setting) {
 		const folder = vscode.workspace.workspaceFolders?.find(f => f.name === name);
 		if (!folder) {
 			return undefined;
@@ -49,28 +50,27 @@ export async function getServerSetting(
 				port: serverForUri.port,
 				pathPrefix: serverForUri.pathPrefix,
 			},
-			username: serverForUri.username,
-			password: serverForUri.password ? serverForUri.password : undefined,
+			authorization: new PasswordAuthorization(serverForUri.username, serverForUri.password),
 			description: `Server for workspace folder "${name}"`,
 		};
 	}
 
-	server.name = name;
-	server.description = server.description || "";
-	server.webServer.scheme = server.webServer.scheme || "http";
-	server.webServer.port = server.webServer.port || (server.webServer.scheme === "https" ? 443 : 80);
-	server.webServer.pathPrefix = server.webServer.pathPrefix || "";
-	if (server.superServer) {
+	const { oauth2, username, password, ...spec } = setting;
+	spec.name = name;
+	spec.description = spec.description || "";
+	spec.webServer.scheme = spec.webServer.scheme || "http";
+	spec.webServer.port = spec.webServer.port || (spec.webServer.scheme === "https" ? 443 : 80);
+	spec.webServer.pathPrefix = spec.webServer.pathPrefix || "";
+	if (spec.superServer) {
 		// Fall back to default if appropriate
-		server.superServer.host = server.superServer.host || server.webServer.host;
+		spec.superServer.host = spec.superServer.host || spec.webServer.host;
 	}
-
-	// When authentication provider is being used we should only have a password if it came from the deprecated
-	// property of the settings object. Otherwise return it as undefined.
-	if (!server["password"]) {
-		server["password"] = undefined;
-	}
-	return server;
+	return {
+		...spec,
+		authorization: (oauth2 !== undefined)
+			? new OAuth2Authorization(oauth2)
+			: new PasswordAuthorization(username || "", password),
+	};
 }
 
 /**

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -14,7 +14,7 @@ export async function getServerSpec(
 	scope?: vscode.ConfigurationScope,
 ): Promise<IServerSpec | undefined> {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	const server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
+	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
 	// Unknown server
 	if (!server) {
 		const folder = vscode.workspace.workspaceFolders?.find(f => f.name === name);

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
+import { IServerSpecWithAuth, VSCodeObjectScriptAPI } from "@intersystems-community/intersystems-servermanager";
 import { IServerSetting } from "../serverSetting";
 import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
@@ -25,40 +25,29 @@ export async function getServerSpec(
 
 		// It is the name of a workspace root folder
 		// Get the server details from the ObjectScript extension if available
-		const objectScriptExtension = vscode.extensions.getExtension(OBJECTSCRIPT_EXTENSIONID);
-		if (!objectScriptExtension) {
-			return undefined;
-		}
-		if (!objectScriptExtension.isActive) {
+		const objectScriptExtension = vscode.extensions.getExtension<VSCodeObjectScriptAPI>(OBJECTSCRIPT_EXTENSIONID);
+		if (!objectScriptExtension?.isActive) {
 			// Activating it here would cause a deadlock because the activate method of the ObjectScript extension itself calls our getServerSpec API
 			return undefined;
 		}
-		let serverForUri: {
-			serverName: string;
-			scheme: string;
-			host: string;
-			port: number;
-			pathPrefix: string;
-			username: string;
-			password?: string;
-		};
-		if (objectScriptExtension.exports.asyncServerForUri) {
-			serverForUri = await objectScriptExtension.exports.asyncServerForUri(folder.uri);
-		} else {
-			serverForUri = objectScriptExtension.exports.serverForUri(folder.uri);
-		}
+		const serverForUri = objectScriptExtension.exports.asyncServerForUri
+			? await objectScriptExtension.exports.asyncServerForUri(folder.uri)
+			: objectScriptExtension.exports.serverForUri(folder.uri);
 		if (!serverForUri) {
 			return undefined;
 		}
+		const { serverName, scheme, host, port, pathPrefix, auth, username, password } = serverForUri;
 		return {
-			name: serverForUri.serverName,
+			name: serverName,
 			webServer: {
-				scheme: serverForUri.scheme,
-				host: serverForUri.host,
-				port: serverForUri.port,
-				pathPrefix: serverForUri.pathPrefix,
+				scheme,
+				host,
+				port,
+				pathPrefix,
 			},
-			auth: new PasswordAuthorization(serverForUri.username, serverForUri.password),
+			username,
+			password,
+			auth: auth ?? new PasswordAuthorization(username, password),
 			description: `Server for workspace folder "${name}"`,
 		};
 	}

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,6 +1,6 @@
 import { IServerSpecWithAuth, VSCodeObjectScriptAPI } from "@intersystems-community/intersystems-servermanager";
 import * as vscode from "vscode";
-import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
+import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, BasicAuthorization } from "../commonActivate";
 import { IServerSetting } from "../serverSetting";
 
 /**
@@ -47,7 +47,7 @@ export async function getServerSpec(
 			},
 			username: username ?? auth?.username,
 			password: (password ?? auth?.password) || undefined,
-			auth: auth ?? new PasswordAuthorization(username, password),
+			auth: auth ?? new BasicAuthorization(username, password),
 			description: `Server for workspace folder "${name}"`,
 		};
 	}
@@ -64,7 +64,7 @@ export async function getServerSpec(
 	}
 	const auth = oauth2
 		? new OAuth2Authorization(oauth2)
-		: new PasswordAuthorization(username, password || undefined);
+		: new BasicAuthorization(username, password);
 	return {
 		...spec,
 		auth,

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -45,8 +45,8 @@ export async function getServerSpec(
 				port,
 				pathPrefix,
 			},
-			username,
-			password,
+			username: username ?? auth?.username,
+			password: (password ?? auth?.password) || undefined,
 			auth: auth ?? new PasswordAuthorization(username, password),
 			description: `Server for workspace folder "${name}"`,
 		};
@@ -64,6 +64,8 @@ export async function getServerSpec(
 	}
 	return {
 		...spec,
+		username,
+		password: password || undefined,
 		auth: oauth2 === undefined
 			? new PasswordAuthorization(username, password)
 			: new OAuth2Authorization(oauth2)

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -62,13 +62,14 @@ export async function getServerSpec(
 		// Fall back to default if appropriate
 		spec.superServer.host = spec.superServer.host || spec.webServer.host;
 	}
+	const auth = oauth2
+		? new OAuth2Authorization(oauth2)
+		: new PasswordAuthorization(username, password || undefined);
 	return {
 		...spec,
-		username,
-		password: password || undefined,
-		auth: oauth2 === undefined
-			? new PasswordAuthorization(username, password)
-			: new OAuth2Authorization(oauth2)
+		auth,
+		username: auth.username,
+		password: auth.password,
 	};
 }
 

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,7 +1,7 @@
-import * as vscode from "vscode";
 import { IServerSpecWithAuth, VSCodeObjectScriptAPI } from "@intersystems-community/intersystems-servermanager";
-import { IServerSetting } from "../serverSetting";
+import * as vscode from "vscode";
 import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
+import { IServerSetting } from "../serverSetting";
 
 /**
  * Get a server specification.
@@ -18,7 +18,7 @@ export async function getServerSpec(
 	const setting = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSetting | undefined || legacyEmbeddedServer(name);
 	// Unknown server
 	if (!setting) {
-		const folder = vscode.workspace.workspaceFolders?.find(f => f.name === name);
+		const folder = vscode.workspace.workspaceFolders?.find((f) => f.name === name);
 		if (!folder) {
 			return undefined;
 		}
@@ -83,32 +83,31 @@ export async function getServerSpec(
 export function legacyEmbeddedServer(name: string): IServerSetting | undefined {
 	return {
 		"default~iris": {
-			"name": "default~iris",
-			"webServer": {
-				"scheme": "http",
-				"host": "127.0.0.1",
-				"port": 52773
+			name: "default~iris",
+			webServer: {
+				scheme: "http",
+				host: "127.0.0.1",
+				port: 52773,
 			},
-			"description": "Connection to local InterSystems IRIS™ installed with default settings."
+			description: "Connection to local InterSystems IRIS™ installed with default settings.",
 		},
 		"default~cache": {
-			"name": "default~cache",
-			"webServer": {
-				"scheme": "http",
-				"host": "127.0.0.1",
-				"port": 57772
+			name: "default~cache",
+			webServer: {
+				scheme: "http",
+				host: "127.0.0.1",
+				port: 57772,
 			},
-			"description": "Connection to local InterSystems Caché installed with default settings."
+			description: "Connection to local InterSystems Caché installed with default settings.",
 		},
 		"default~ensemble": {
-			"name": "default~ensemble",
-			"webServer": {
-				"scheme": "http",
-				"host": "127.0.0.1",
-				"port": 57772
+			name: "default~ensemble",
+			webServer: {
+				scheme: "http",
+				host: "127.0.0.1",
+				port: 57772,
 			},
-			"description": "Connection to local InterSystems Ensemble installed with default settings."
-		}
+			description: "Connection to local InterSystems Ensemble installed with default settings.",
+		},
 	}[name];
 }
-

--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
 import { IServerSetting } from "../serverSetting";
 import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
@@ -13,7 +13,7 @@ import { OAuth2Authorization, OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } 
 export async function getServerSpec(
 	name: string,
 	scope?: vscode.ConfigurationScope,
-): Promise<IServerSpec | undefined> {
+): Promise<IServerSpecWithAuth | undefined> {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
 	const setting = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSetting | undefined || legacyEmbeddedServer(name);
 	// Unknown server

--- a/src/api/getServerSummary.ts
+++ b/src/api/getServerSummary.ts
@@ -4,7 +4,7 @@ import { legacyEmbeddedServer } from "./getServerSpec";
 
 export function getServerSummary(name: string, scope?: vscode.ConfigurationScope): IServerName | undefined {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	const server: IServerSpec | undefined = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) || legacyEmbeddedServer(name);
+	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
 	if (!server) {
 		return undefined;
 	}

--- a/src/api/getServerSummary.ts
+++ b/src/api/getServerSummary.ts
@@ -1,16 +1,17 @@
 import * as vscode from "vscode";
-import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerName } from "@intersystems-community/intersystems-servermanager";
 import { legacyEmbeddedServer } from "./getServerSpec";
+import { IServerSetting } from "../serverSetting";
 
 export function getServerSummary(name: string, scope?: vscode.ConfigurationScope): IServerName | undefined {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature
-	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSpec | undefined || legacyEmbeddedServer(name);
+	const server = vscode.workspace.getConfiguration("intersystems.servers", scope).get(name) as IServerSetting | undefined || legacyEmbeddedServer(name);
 	if (!server) {
 		return undefined;
 	}
 	return { name, description: server.description || "", detail: serverDetail(server), scope };
 }
 
-export function serverDetail(connSpec: IServerSpec): string {
+export function serverDetail(connSpec: IServerSetting): string {
 	return `${connSpec.webServer.scheme || "http"}://${connSpec.webServer.host}:${connSpec.webServer.port}${connSpec.webServer.pathPrefix || ""}/`;
 }

--- a/src/api/getServerSummary.ts
+++ b/src/api/getServerSummary.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { IServerName } from "@intersystems-community/intersystems-servermanager";
-import { legacyEmbeddedServer } from "./getServerSpec";
 import { IServerSetting } from "../serverSetting";
+import { legacyEmbeddedServer } from "./getServerSpec";
 
 export function getServerSummary(name: string, scope?: vscode.ConfigurationScope): IServerName | undefined {
 	// To avoid breaking existing users, continue to return a default server definition even after we dropped that feature

--- a/src/api/getServerSummary.ts
+++ b/src/api/getServerSummary.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
 import { IServerName } from "@intersystems-community/intersystems-servermanager";
+import * as vscode from "vscode";
 import { IServerSetting } from "../serverSetting";
 import { legacyEmbeddedServer } from "./getServerSpec";
 

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -244,7 +244,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec: IServerSpec | undefined = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth: session.authorization }).catch(() => { /* Swallow errors */ });
+			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth: session.auth }).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -15,13 +15,39 @@ import {
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { Authorization, globalState, OAuth2Authorization, PasswordAuthorization, ResolvedAuthorization } from "./commonActivate";
-import { getServerSpec } from "./api/getServerSpec";
+import { getAuthFromSetting, getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { AuthRelatedSetting } from "./serverSetting";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
+
+interface StrippedSession {
+	/** Session ID */
+	id: string;
+	serverName: string;
+	server: AuthRelatedSetting;
+}
+
+function isValidStrippedSession(data: unknown): data is StrippedSession {
+	if (!data || typeof data !== 'object') return false;
+	const session = data as Partial<StrippedSession>;
+	// Required fields
+	if (typeof session.id !== 'string' || !session.id) return false;
+	if (typeof session.serverName !== 'string' || !session.serverName) return false;
+	if (session.server && typeof session.server === 'object') {
+		const server = session.server as Partial<AuthRelatedSetting>;
+		if (typeof server.username !== 'string' && !server.oauth2) return false;
+		return true;
+	} else if (typeof session["userName"] === 'string' && session["username"]) {
+		session.server = { username: session["username"] }
+		return true
+	} else {
+		return false;
+	}
+}
 
 export class ServerManagerAuthenticationProvider implements AuthenticationProvider, Disposable {
 	public static id = AUTHENTICATION_PROVIDER;
@@ -101,12 +127,12 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				clientId: spec.auth.oauth2.clientId,
 				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
 			});
-			if (!accessToken) {
-				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
-			}
 			const auth: Authorization = new OAuth2Authorization(spec.auth.oauth2);
-			auth.resolve({ accessToken: accessToken, username: "OAuth2User" });
-			return this._finalizeSession(serverName, auth);
+			if (auth.resolve({ accessToken: accessToken, username: "OAuth2User" })) {
+				return this._finalizeSession(serverName, auth);
+			} else {
+				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
+			};
 		} else {
 			const userName = scopes[1] || await this.promptUserName(serverName);
 			// Return existing session if found
@@ -125,8 +151,11 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 			const password = userName && await this.seekPassword(sessionId, userName, serverName);
 			const auth: Authorization = new PasswordAuthorization();
-			auth.resolve({ accessToken: password, username: userName || "UnknownUser" });
-			return this._finalizeSession(serverName, auth);
+			if (auth.resolve({ accessToken: password, username: userName || "UnknownUser" })) {
+				return this._finalizeSession(serverName, auth);
+			} else {
+				throw new Error("Internal error: username or password is invalid");
+			};
 		}
 	}
 
@@ -361,10 +390,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 								} else {
 									this._sessions[index] = new ServerManagerAuthenticationSession(
 										session.serverName,
-										PasswordAuthorization.new(
+										new PasswordAuthorization(
 											session.userName,
 											password
-										)
+										) as ResolvedAuthorization
 									);
 								}
 							}
@@ -382,50 +411,48 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	}
 
 	private async _reloadSessions() {
-		const strippedSessions = globalState.get<ServerManagerAuthenticationSession[]>(
+		const strippedSessions = globalState.get<unknown[]>(
 			"authenticationProvider.strippedSessions",
 			[],
-		);
-
+		).filter(isValidStrippedSession);
 		// Build our array of sessions for which non-empty accessTokens were securely persisted
-		this._sessions = (await Promise.all(
+		const maybeSessions = await Promise.all(
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
 				const accessToken = await this._secretStorage.get(credentialKey);
-				return new ServerManagerAuthenticationSession(session.serverName, PasswordAuthorization.new(session.userName, accessToken));
-			}),
-		)).filter((session) => session.accessToken).sort((a, b) => {
-			const aUserNameLowercase = a.userName.toLowerCase();
-			const bUserNameLowercase = b.userName.toLowerCase();
-			if (aUserNameLowercase < bUserNameLowercase) {
-				return -1;
-			}
-			if (aUserNameLowercase > bUserNameLowercase) {
+				const auth: Authorization = await getAuthFromSetting(session.server);
+				if (auth.resolve({ accessToken, username: auth.username })) {
+					return new ServerManagerAuthenticationSession(session.serverName, auth);
+				}
+			})
+		);
+		const sessions = maybeSessions.filter((session) => session !== undefined) as ServerManagerAuthenticationSession[];
+		this._sessions = sessions
+			.sort((a, b) => {
+				const aUserNameLowercase = a.userName.toLowerCase();
+				const bUserNameLowercase = b.userName.toLowerCase();
+				if (aUserNameLowercase < bUserNameLowercase) {
+					return -1;
+				}
+				if (aUserNameLowercase > bUserNameLowercase) {
+					return 1;
+				}
+				if (a.serverName < b.serverName) {
+					return -1;
+				}
 				return 1;
-			}
-			if (a.serverName < b.serverName) {
-				return -1;
-			}
-			return 1;
-		});
+			});
 	}
 
 	private async _storeStrippedSessions() {
-		// Build an array of sessions with passwords blanked
-		const strippedSessions = this._sessions.map((session) => {
-			return new ServerManagerAuthenticationSession(
-				session.serverName,
-				PasswordAuthorization.new(
-					session.userName,
-					""
-				),
-			);
-		});
-
-		// Persist it
+		// Build an array of sessions with accessToken blanked
 		await globalState.update(
 			"authenticationProvider.strippedSessions",
-			strippedSessions,
+			this._sessions.map((session): StrippedSession => ({
+				id: session.id,
+				serverName: session.serverName,
+				server: session.auth.setting,
+			})),
 		);
 	}
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -131,8 +131,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			};
 		} else {
 			const password = userName && await this.seekPassword(sessionId, userName, serverName);
-			const auth: Authorization = new PasswordAuthorization();
-			if (auth.resolve({ accessToken: password, username: userName || "UnknownUser" })) {
+			const auth: Authorization = new PasswordAuthorization(userName, password);
+			if (auth.resolved()) {
 				return this._finalizeSession(serverName, auth);
 			} else {
 				throw new Error("Internal error: username or password is invalid");

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -127,7 +127,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	}
 
 	private async _createOAuth2Session(serverName: string, serverSpec: IServerSpecOAuth2): Promise<AuthenticationSession> {
-		const userName = serverSpec.username || "OAuth2User";
+		const userName = "OAuth2User";
 
 		// Resolve OAuth2 config — prompt for missing values
 		const oauth2Config = await resolveOAuth2Config(serverName, serverSpec);

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -1,4 +1,4 @@
-import { IServerSpec, OAuth2IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { OAuth2IServerSetting } from "./serverSetting";
 import {
 	authentication,
 	AuthenticationProvider,
@@ -16,7 +16,7 @@ import {
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState } from "./commonActivate";
-import { getServerSpec } from "./api/getServerSpec";
+import { getServerSetting } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
 
@@ -109,10 +109,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 
 		// Check auth method early to branch the flow
-		const serverSpec = await getServerSpec(serverName) as IServerSpec | undefined;
+		const serverSetting = await getServerSetting(serverName);
 
-		if (serverSpec?.authMethod === "oauth2") {
-			return this._createOAuth2Session(serverName, serverSpec);
+		if (serverSetting && 'oauth2' in serverSetting) {
+			return this._createOAuth2Session(serverName, serverSetting);
 		} else {
 			return this._createPasswordSession(serverName, scopes[1] ?? "");
 		}
@@ -161,9 +161,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		await this._storeStrippedSessions();
 		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
 	}
-	private async _createOAuth2Session(serverName: string, serverSpec: OAuth2IServerSpec): Promise<AuthenticationSession> {
+	private async _createOAuth2Session(serverName: string, serverSetting: OAuth2IServerSetting): Promise<AuthenticationSession> {
 		// Resolve OAuth2 config — prompt for missing values
-		const oauth2Config = await resolveOAuth2Config(serverSpec);
+		const oauth2Config = await resolveOAuth2Config(serverSetting);
 		if (!oauth2Config) {
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 configuration is required.`);
 		}
@@ -175,7 +175,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 
 		// Token is stored as the session's accessToken (password field) and sent as Bearer token
-		return this._finalizeSession(serverName, serverSpec.username || "OAuth2User", token);
+		return this._finalizeSession(serverName, "OAuth2User", token);
 	}
 
 	private async _createPasswordSession(serverName: string, scopeUserName: string): Promise<AuthenticationSession> {
@@ -297,11 +297,11 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (this._checkedSessions.find((s) => s.id === session.id)) {
 			return true;
 		}
-		const serverSpec = await getServerSpec(session.serverName);
-		if (serverSpec && serverSpec.authMethod !== "oauth2") {
-			serverSpec.username = session.userName;
-			serverSpec.password = session.accessToken;
-			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
+		const serverSetting = await getServerSetting(session.serverName);
+		if (serverSetting && !('oauth2' in serverSetting)) {
+			serverSetting.username = session.userName;
+			serverSetting.password = session.accessToken;
+			const response = await makeRESTRequest("HEAD", serverSetting).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;
@@ -445,7 +445,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
  * Persists each value to settings immediately so progress isn't lost.
  */
 async function resolveOAuth2Config(
-	serverSpec: OAuth2IServerSpec,
+	serverSetting: OAuth2IServerSetting,
 ): Promise<{ authority: string; clientId: string; audience: string; scopes?: string[] } | undefined> {
-	return { authority: serverSpec.oauth2.authority, clientId: serverSpec.oauth2.clientId, audience: `${serverSpec.webServer.scheme || "http"}://${serverSpec.webServer.host}:${serverSpec.webServer.port}/` };
+	return { authority: serverSetting.oauth2.authority, clientId: serverSetting.oauth2.clientId, audience: `${serverSetting.webServer.scheme || "http"}://${serverSetting.webServer.host}:${serverSetting.webServer.port}/` };
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -14,10 +14,11 @@ import {
 	workspace,
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
-import { globalState, OAuth2Authorization } from "./commonActivate";
+import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
+import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -103,31 +104,50 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			if (!token) {
 				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
 			}
-			return this._finalizeSession(serverName, "OAuth2User", token);
-		}
-		const userName = scopes[1] || await this.promptUserName(serverName);
-		// Return existing session if found
-		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-		const existingSession = this._sessions.find((s) => s.id === sessionId);
-		if (existingSession) {
-			if (this._checkedSessions.find((s) => s.id === sessionId)) {
-				return existingSession;
-			}
+			const auth: Authorization = new OAuth2Authorization(spec.authorization.oauth2);
+			auth.resolve(token, "OAuth2User");
+			return this._finalizeSession(serverName, auth);
+		} else {
+			const userName = scopes[1] || await this.promptUserName(serverName);
+			// Return existing session if found
+			const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
+			const existingSession = this._sessions.find((s) => s.id === sessionId);
+			if (existingSession) {
+				if (this._checkedSessions.find((s) => s.id === sessionId)) {
+					return existingSession;
+				}
 
-			// Check if the session is still valid
-			if (await this._isStillValid(existingSession)) {
-				this._checkedSessions.push(existingSession);
-				return existingSession;
+				// Check if the session is still valid
+				if (await this._isStillValid(existingSession)) {
+					this._checkedSessions.push(existingSession);
+					return existingSession;
+				}
 			}
+			const password = userName && await this.seekPassword(sessionId, userName, serverName);
+			const auth: Authorization = new PasswordAuthorization();
+			auth.resolve(userName || "UnknownUser", password);
+			return this._finalizeSession(serverName, auth);
 		}
-		const password = userName && await this.seekPassword(sessionId, userName, serverName);
-		return this._finalizeSession(serverName, userName || "UnknownUser", password ?? "");
 	}
 
-	// Seek password in secret storage
-	private async seekPassword(sessionId: string, userName: string, serverName: string): Promise<string | undefined> {
-		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-		return await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
+	private async _finalizeSession(serverName: string, auth: ResolvedAuthorization): Promise<AuthenticationSession> {
+		// We have all we need to create the session object
+		const session = new ServerManagerAuthenticationSession(serverName, auth);
+		// Update this._sessions and raise the event to notify
+		const added: AuthenticationSession[] = [];
+		const changed: AuthenticationSession[] = [];
+		const index = this._sessions.findIndex((item) => item.id === session.id);
+		if (index !== -1) {
+			this._sessions[index] = session;
+			changed.push(session);
+		} else {
+			// No point re-sorting here because onDidChangeSessions always appends added items to the provider's entries in the Accounts menu
+			this._sessions.push(session);
+			added.push(session);
+		}
+		await this._storeStrippedSessions();
+		this._onDidChangeSessions.fire({ added, removed: [], changed });
+		return session;
 	}
 
 	private async promptServerName(): Promise<string> {
@@ -158,7 +178,13 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return enteredUserName;
 	}
 
-	private async promptPassword(userName: string, serverName: string, credentialKey: string): Promise<string | undefined> {
+	private async seekPassword(sessionId: string, userName: string, serverName: string): Promise<string> {
+		// Seek password in secret storage
+		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+		return await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
+	}
+
+	private async promptPassword(userName: string, serverName: string, credentialKey: string): Promise<string> {
 		const doInputBox = async (): Promise<string | undefined> => {
 			return await new Promise<string | undefined>((resolve, reject) => {
 				const inputBox = window.createInputBox();
@@ -212,33 +238,14 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return password;
 	}
 
-	private async _finalizeSession(serverName: string, userName: string, password: string): Promise<AuthenticationSession> {
-		// We have all we need to create the session object
-		const session = new ServerManagerAuthenticationSession(serverName, userName, password);
-		// Update this._sessions and raise the event to notify
-		const added: AuthenticationSession[] = [];
-		const changed: AuthenticationSession[] = [];
-		const index = this._sessions.findIndex((item) => item.id === session.id);
-		if (index !== -1) {
-			this._sessions[index] = session;
-			changed.push(session);
-		} else {
-			// No point re-sorting here because onDidChangeSessions always appends added items to the provider's entries in the Accounts menu
-			this._sessions.push(session);
-			added.push(session);
-		}
-		await this._storeStrippedSessions();
-		this._onDidChangeSessions.fire({ added, removed: [], changed });
-		return session;
-	}
-
 	private async _isStillValid(session: ServerManagerAuthenticationSession): Promise<boolean> {
 		if (this._checkedSessions.find((s) => s.id === session.id)) {
 			return true;
 		}
 		const serverSpec = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			serverSpec.authorization.resolve(session.accessToken, session.userName);
+			const auth: Authorization = serverSpec.authorization;
+			auth.resolve(session.accessToken, session.userName);
 			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
@@ -356,8 +363,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 								} else {
 									this._sessions[index] = new ServerManagerAuthenticationSession(
 										session.serverName,
-										session.userName,
-										password,
+										PasswordAuthorization.new(
+											session.userName,
+											password
+										)
 									);
 								}
 							}
@@ -385,7 +394,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
 				const accessToken = await this._secretStorage.get(credentialKey);
-				return new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken);
+				return new ServerManagerAuthenticationSession(session.serverName, PasswordAuthorization.new(session.userName, accessToken));
 			}),
 		)).filter((session) => session.accessToken).sort((a, b) => {
 			const aUserNameLowercase = a.userName.toLowerCase();
@@ -408,8 +417,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		const strippedSessions = this._sessions.map((session) => {
 			return new ServerManagerAuthenticationSession(
 				session.serverName,
-				session.userName,
-				"",
+				PasswordAuthorization.new(
+					session.userName,
+					""
+				),
 			);
 		});
 

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -14,11 +14,11 @@ import {
 	workspace,
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
-import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
+import { Authorization, globalState, OAuth2Authorization, PasswordAuthorization, ResolvedAuthorization } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
-import { Authorization, IServerSpec, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -96,16 +96,16 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		const serverName = scopes[0] || await this.promptServerName();
 		const spec = await getServerSpec(serverName);
 		if (spec?.auth instanceof OAuth2Authorization) {
-			const token = await performOAuth2Login({
+			const accessToken = await performOAuth2Login({
 				authority: spec.auth.oauth2.authority,
 				clientId: spec.auth.oauth2.clientId,
 				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
 			});
-			if (!token) {
+			if (!accessToken) {
 				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
 			}
 			const auth: Authorization = new OAuth2Authorization(spec.auth.oauth2);
-			auth.resolve(token, "OAuth2User");
+			auth.resolve({ accessToken: accessToken, username: "OAuth2User" });
 			return this._finalizeSession(serverName, auth);
 		} else {
 			const userName = scopes[1] || await this.promptUserName(serverName);
@@ -125,7 +125,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 			const password = userName && await this.seekPassword(sessionId, userName, serverName);
 			const auth: Authorization = new PasswordAuthorization();
-			auth.resolve(userName || "UnknownUser", password);
+			auth.resolve({ accessToken: password, username: userName || "UnknownUser" });
 			return this._finalizeSession(serverName, auth);
 		}
 	}

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -35,7 +35,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	public static label = AUTHENTICATION_PROVIDER_LABEL;
 	public static secretKeyPrefix = "credentialProvider:";
 	public static sessionId(serverName: string, userName: string): string {
-		const canonicalUserName = (userName || "").toLowerCase();
+		const canonicalUserName = userName.toLowerCase();
 		return `${serverName}/${canonicalUserName}`;
 	}
 	public static credentialKey(sessionId: string): string {
@@ -117,27 +117,23 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				return existingSession;
 			}
 		}
+		let auth: Authorization;
 		if (spec?.auth instanceof OAuth2Authorization) {
 			const accessToken = await performOAuth2Login({
 				authority: spec.auth.oauth2.authority,
 				clientId: spec.auth.oauth2.clientId,
 				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
 			});
-			const auth: Authorization = new OAuth2Authorization(spec.auth.oauth2);
-			if (auth.resolve({ accessToken: accessToken, username: "OAuth2User" })) {
-				return this._finalizeSession(serverName, auth);
-			} else {
-				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
-			};
+			auth = new OAuth2Authorization(spec.auth.oauth2, accessToken);
 		} else {
 			const password = userName && await this.seekPassword(sessionId, userName, serverName);
-			const auth: Authorization = new PasswordAuthorization(userName, password);
-			if (auth.resolved()) {
-				return this._finalizeSession(serverName, auth);
-			} else {
-				throw new Error("Internal error: username or password is invalid");
-			};
+			auth = new PasswordAuthorization(userName, password);
 		}
+		if (auth.resolved()) {
+			return this._finalizeSession(serverName, auth);
+		} else {
+			throw new Error("Internal error: Authorization should already be resolved");
+		};
 	}
 
 	private async _finalizeSession(serverName: string, auth: ResolvedAuthorization): Promise<AuthenticationSession> {
@@ -254,7 +250,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec: IServerSpec | undefined = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			const auth = serverSpec.auth;
+			const auth = serverSpec.auth.clone();
 			auth.resolve({ accessToken: session.accessToken })
 			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth }).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
@@ -401,7 +397,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
 				const accessToken = await this._secretStorage.get(credentialKey);
-				return new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken);
+				if (accessToken !== undefined) {
+					return new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken);
+				}
 			})
 		);
 		const sessions = maybeSessions.filter((session) => session !== undefined) as ServerManagerAuthenticationSession[];

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -244,7 +244,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec: IServerSpec | undefined = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			const response = await makeRESTRequest("HEAD", { ...serverSpec, authorization: session.authorization }).catch(() => { /* Swallow errors */ });
+			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth: session.authorization }).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -20,7 +20,7 @@ import { globalState } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { IOAuth2Config, performOAuth2Login } from "./oauth2Flow";
-import { promptOAuth2Audience, promptOAuth2Authority, promptOAuth2ClientId } from "./oauth2Prompts";
+import { promptOAuth2Authority, promptOAuth2ClientId } from "./oauth2Prompts";
 
 /** Extended server spec with OAuth2 support (internal only) */
 interface IServerSpecOAuth2 extends IServerSpec {
@@ -484,15 +484,7 @@ async function resolveOAuth2Config(
 	}
 
 	// Audience
-	let audience = existing?.audience;
-	if (!audience) {
-		const defaultAudience = `${serverSpec.webServer.scheme || "http"}://${serverSpec.webServer.host}:${serverSpec.webServer.port}/`;
-		audience = await promptOAuth2Audience(serverName, defaultAudience);
-		if (!audience) { return undefined; }
-		const sc = config.get<any>(serverName) || {};
-		sc.oauth2 = { ...sc.oauth2, audience };
-		await config.update(serverName, sc, ConfigurationTarget.Global);
-	}
+	const audience = `${serverSpec.webServer.scheme || "http"}://${serverSpec.webServer.host}:${serverSpec.webServer.port}/`;
 
 	return { authority, clientId, audience };
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -1,3 +1,4 @@
+import { IServerSpec, OAuth2IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import {
 	authentication,
 	AuthenticationProvider,
@@ -19,8 +20,6 @@ import { globalState } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
-import { promptOAuth2Authority, promptOAuth2ClientId } from "./oauth2Prompts";
-import { IServerSpec, OAuth2IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -119,9 +118,53 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return this._createPasswordSession(serverName, scopes[1] ?? "");
 		}
 	}
+
+	// This function is called when the end user signs out of the account.
+	public async removeSession(sessionId: string): Promise<void> {
+		this._removeSession(sessionId);
+	}
+
+	public async removeSessions(sessionIds: string[]): Promise<void> {
+		const storedPasswordCredKeys: string[] = [];
+		const removed: AuthenticationSession[] = [];
+		await Promise.allSettled(sessionIds.map(async (sessionId) => {
+			const index = this._sessions.findIndex((item) => item.id === sessionId);
+			const session = this._sessions[index];
+			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+			if (await this.secretStorage.get(credentialKey) !== undefined) {
+				storedPasswordCredKeys.push(credentialKey);
+			}
+			if (index > -1) {
+				this._sessions.splice(index, 1);
+			}
+			removed.push(session);
+		}));
+		if (storedPasswordCredKeys.length) {
+			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
+				.get<string>("deletePasswordOnSignout", "ask");
+			let deletePasswords = (passwordOption === "always");
+			if (passwordOption === "ask") {
+				const choice = await window.showWarningMessage(
+					`Do you want to keep the stored passwords or delete them?`,
+					{
+						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
+							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
+					},
+					{ title: "Keep", isCloseAffordance: true },
+					{ title: "Delete", isCloseAffordance: false },
+				);
+				deletePasswords = (choice?.title === "Delete");
+			}
+			if (deletePasswords) {
+				await Promise.allSettled(storedPasswordCredKeys.map((e) => this.secretStorage.delete(e)));
+			}
+		}
+		await this._storeStrippedSessions();
+		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
+	}
 	private async _createOAuth2Session(serverName: string, serverSpec: OAuth2IServerSpec): Promise<AuthenticationSession> {
 		// Resolve OAuth2 config — prompt for missing values
-		const oauth2Config = await resolveOAuth2Config(serverName, serverSpec);
+		const oauth2Config = await resolveOAuth2Config(serverSpec);
 		if (!oauth2Config) {
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 configuration is required.`);
 		}
@@ -271,11 +314,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return true;
 	}
 
-	// This function is called when the end user signs out of the account.
-	public async removeSession(sessionId: string): Promise<void> {
-		this._removeSession(sessionId);
-	}
-
 	private async _removeSession(sessionId: string, alwaysDeletePassword = false): Promise<void> {
 		const index = this._sessions.findIndex((item) => item.id === sessionId);
 		const session = this._sessions[index];
@@ -311,45 +349,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		await this._storeStrippedSessions();
 		this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
-	}
-
-	public async removeSessions(sessionIds: string[]): Promise<void> {
-		const storedPasswordCredKeys: string[] = [];
-		const removed: AuthenticationSession[] = [];
-		await Promise.allSettled(sessionIds.map(async (sessionId) => {
-			const index = this._sessions.findIndex((item) => item.id === sessionId);
-			const session = this._sessions[index];
-			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-			if (await this.secretStorage.get(credentialKey) !== undefined) {
-				storedPasswordCredKeys.push(credentialKey);
-			}
-			if (index > -1) {
-				this._sessions.splice(index, 1);
-			}
-			removed.push(session);
-		}));
-		if (storedPasswordCredKeys.length) {
-			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
-				.get<string>("deletePasswordOnSignout", "ask");
-			let deletePasswords = (passwordOption === "always");
-			if (passwordOption === "ask") {
-				const choice = await window.showWarningMessage(
-					`Do you want to keep the stored passwords or delete them?`,
-					{
-						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
-							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
-					},
-					{ title: "Keep", isCloseAffordance: true },
-					{ title: "Delete", isCloseAffordance: false },
-				);
-				deletePasswords = (choice?.title === "Delete");
-			}
-			if (deletePasswords) {
-				await Promise.allSettled(storedPasswordCredKeys.map((e) => this.secretStorage.delete(e)));
-			}
-		}
-		await this._storeStrippedSessions();
-		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
 	}
 
 	private async _ensureInitialized(): Promise<void> {
@@ -447,35 +446,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
  * Persists each value to settings immediately so progress isn't lost.
  */
 async function resolveOAuth2Config(
-	serverName: string,
 	serverSpec: OAuth2IServerSpec,
 ): Promise<{ authority: string; clientId: string; audience: string; scopes?: string[] } | undefined> {
-
-	const existing: Partial<OAuth2IServerSpec["oauth2"]> = serverSpec.oauth2;
-	const config = workspace.getConfiguration("intersystems.servers");
-
-	// Authority
-	let authority = existing?.authority;
-	if (!authority) {
-		authority = await promptOAuth2Authority(serverName);
-		if (!authority) { return undefined; }
-		const sc = config.get<any>(serverName) || {};
-		sc.oauth2 = { ...sc.oauth2, authority };
-		await config.update(serverName, sc, ConfigurationTarget.Global);
-	}
-
-	// Client ID
-	let clientId = existing?.clientId;
-	if (!clientId) {
-		clientId = await promptOAuth2ClientId(serverName);
-		if (!clientId) { return undefined; }
-		const sc = config.get<any>(serverName) || {};
-		sc.oauth2 = { ...sc.oauth2, clientId };
-		await config.update(serverName, sc, ConfigurationTarget.Global);
-	}
-
-	// Audience
-	const audience = `${serverSpec.webServer.scheme || "http"}://${serverSpec.webServer.host}:${serverSpec.webServer.port}/`;
-
-	return { authority, clientId, audience };
+	return { authority: serverSpec.oauth2.authority, clientId: serverSpec.oauth2.clientId, audience: `${serverSpec.webServer.scheme || "http"}://${serverSpec.webServer.host}:${serverSpec.webServer.port}/` };
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -112,50 +112,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return this._createSession(serverName, scopes[1] ?? "", serverSpec);
 	}
 
-	// This function is called when the end user signs out of the account.
-	public async removeSession(sessionId: string): Promise<void> {
-		this._removeSession(sessionId);
-	}
-
-	public async removeSessions(sessionIds: string[]): Promise<void> {
-		const storedPasswordCredKeys: string[] = [];
-		const removed: AuthenticationSession[] = [];
-		await Promise.allSettled(sessionIds.map(async (sessionId) => {
-			const index = this._sessions.findIndex((item) => item.id === sessionId);
-			const session = this._sessions[index];
-			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-			if (await this.secretStorage.get(credentialKey) !== undefined) {
-				storedPasswordCredKeys.push(credentialKey);
-			}
-			if (index > -1) {
-				this._sessions.splice(index, 1);
-			}
-			removed.push(session);
-		}));
-		if (storedPasswordCredKeys.length) {
-			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
-				.get<string>("deletePasswordOnSignout", "ask");
-			let deletePasswords = (passwordOption === "always");
-			if (passwordOption === "ask") {
-				const choice = await window.showWarningMessage(
-					`Do you want to keep the stored passwords or delete them?`,
-					{
-						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
-							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
-					},
-					{ title: "Keep", isCloseAffordance: true },
-					{ title: "Delete", isCloseAffordance: false },
-				);
-				deletePasswords = (choice?.title === "Delete");
-			}
-			if (deletePasswords) {
-				await Promise.allSettled(storedPasswordCredKeys.map((e) => this.secretStorage.delete(e)));
-			}
-		}
-		await this._storeStrippedSessions();
-		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
-	}
-
 	private async _createSession(serverName: string, scopeUserName: string, spec?: IServerSpec): Promise<AuthenticationSession> {
 		if (spec?.authorization instanceof OAuth2Authorization) {
 			const token = await performOAuth2Login({
@@ -302,6 +258,11 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return true;
 	}
 
+	// This function is called when the end user signs out of the account.
+	public async removeSession(sessionId: string): Promise<void> {
+		this._removeSession(sessionId);
+	}
+
 	private async _removeSession(sessionId: string, alwaysDeletePassword = false): Promise<void> {
 		const index = this._sessions.findIndex((item) => item.id === sessionId);
 		const session = this._sessions[index];
@@ -337,6 +298,45 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		await this._storeStrippedSessions();
 		this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
+	}
+
+	public async removeSessions(sessionIds: string[]): Promise<void> {
+		const storedPasswordCredKeys: string[] = [];
+		const removed: AuthenticationSession[] = [];
+		await Promise.allSettled(sessionIds.map(async (sessionId) => {
+			const index = this._sessions.findIndex((item) => item.id === sessionId);
+			const session = this._sessions[index];
+			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+			if (await this.secretStorage.get(credentialKey) !== undefined) {
+				storedPasswordCredKeys.push(credentialKey);
+			}
+			if (index > -1) {
+				this._sessions.splice(index, 1);
+			}
+			removed.push(session);
+		}));
+		if (storedPasswordCredKeys.length) {
+			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
+				.get<string>("deletePasswordOnSignout", "ask");
+			let deletePasswords = (passwordOption === "always");
+			if (passwordOption === "ask") {
+				const choice = await window.showWarningMessage(
+					`Do you want to keep the stored passwords or delete them?`,
+					{
+						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
+							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
+					},
+					{ title: "Keep", isCloseAffordance: true },
+					{ title: "Delete", isCloseAffordance: false },
+				);
+				deletePasswords = (choice?.title === "Delete");
+			}
+			if (deletePasswords) {
+				await Promise.allSettled(storedPasswordCredKeys.map((e) => this.secretStorage.delete(e)));
+			}
+		}
+		await this._storeStrippedSessions();
+		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
 	}
 
 	private async _ensureInitialized(): Promise<void> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -15,11 +15,10 @@ import {
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { Authorization, globalState, OAuth2Authorization, PasswordAuthorization, ResolvedAuthorization } from "./commonActivate";
-import { getAuthFromSetting, getServerSpec } from "./api/getServerSpec";
+import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
-import { AuthRelatedSetting } from "./serverSetting";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -28,25 +27,7 @@ interface StrippedSession {
 	/** Session ID */
 	id: string;
 	serverName: string;
-	server: AuthRelatedSetting;
-}
-
-function isValidStrippedSession(data: unknown): data is StrippedSession {
-	if (!data || typeof data !== 'object') return false;
-	const session = data as Partial<StrippedSession>;
-	// Required fields
-	if (typeof session.id !== 'string' || !session.id) return false;
-	if (typeof session.serverName !== 'string' || !session.serverName) return false;
-	if (session.server && typeof session.server === 'object') {
-		const server = session.server as Partial<AuthRelatedSetting>;
-		if (typeof server.username !== 'string' && !server.oauth2) return false;
-		return true;
-	} else if (typeof session["userName"] === 'string' && session["username"]) {
-		session.server = { username: session["username"] }
-		return true
-	} else {
-		return false;
-	}
+	userName: string;
 }
 
 export class ServerManagerAuthenticationProvider implements AuthenticationProvider, Disposable {
@@ -54,7 +35,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	public static label = AUTHENTICATION_PROVIDER_LABEL;
 	public static secretKeyPrefix = "credentialProvider:";
 	public static sessionId(serverName: string, userName: string): string {
-		const canonicalUserName = userName.toLowerCase();
+		const canonicalUserName = (userName || "").toLowerCase();
 		return `${serverName}/${canonicalUserName}`;
 	}
 	public static credentialKey(sessionId: string): string {
@@ -91,7 +72,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 		// Filter to return only those that match all supplied scopes, which are positional and case-insensitive.
 		for (let index = 0; index < scopes.length; index++) {
-			sessions = sessions.filter((session) => session.scopes[index].toLowerCase() === scopes[index].toLowerCase());
+			sessions = sessions.filter((session) => session.scopes[index]?.toLowerCase() === scopes[index]?.toLowerCase());
 		}
 
 		if (options.account) {
@@ -99,7 +80,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			const serverName = accountParts.shift();
 			const userName = accountParts.join('/');
 			if (serverName && userName) {
-				sessions = sessions.filter((session) => session.scopes[0] === serverName && session.scopes[1].toLowerCase() === userName.toLowerCase());
+				sessions = sessions.filter((session) => session.scopes[0] === serverName && session.scopes[1]?.toLowerCase() === userName.toLowerCase());
 			}
 		}
 
@@ -161,7 +142,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 	private async _finalizeSession(serverName: string, auth: ResolvedAuthorization): Promise<AuthenticationSession> {
 		// We have all we need to create the session object
-		const session = new ServerManagerAuthenticationSession(serverName, auth);
+		const session = new ServerManagerAuthenticationSession(serverName, auth.username, auth.accessToken);
 		// Update this._sessions and raise the event to notify
 		const added: AuthenticationSession[] = [];
 		const changed: AuthenticationSession[] = [];
@@ -273,7 +254,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec: IServerSpec | undefined = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth: session.auth }).catch(() => { /* Swallow errors */ });
+			const auth = serverSpec.auth;
+			auth.resolve({ accessToken: session.accessToken })
+			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth }).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;
@@ -390,10 +373,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 								} else {
 									this._sessions[index] = new ServerManagerAuthenticationSession(
 										session.serverName,
-										new PasswordAuthorization(
-											session.userName,
-											password
-										) as ResolvedAuthorization
+										session.userName,
+										password
 									);
 								}
 							}
@@ -411,26 +392,23 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	}
 
 	private async _reloadSessions() {
-		const strippedSessions = globalState.get<unknown[]>(
+		const strippedSessions = globalState.get<StrippedSession[]>(
 			"authenticationProvider.strippedSessions",
 			[],
-		).filter(isValidStrippedSession);
+		);
 		// Build our array of sessions for which non-empty accessTokens were securely persisted
 		const maybeSessions = await Promise.all(
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
 				const accessToken = await this._secretStorage.get(credentialKey);
-				const auth: Authorization = await getAuthFromSetting(session.server);
-				if (auth.resolve({ accessToken, username: auth.username })) {
-					return new ServerManagerAuthenticationSession(session.serverName, auth);
-				}
+				return new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken);
 			})
 		);
 		const sessions = maybeSessions.filter((session) => session !== undefined) as ServerManagerAuthenticationSession[];
 		this._sessions = sessions
 			.sort((a, b) => {
-				const aUserNameLowercase = a.userName.toLowerCase();
-				const bUserNameLowercase = b.userName.toLowerCase();
+				const aUserNameLowercase = (a.userName || "").toLowerCase();
+				const bUserNameLowercase = (b.userName || "").toLowerCase();
 				if (aUserNameLowercase < bUserNameLowercase) {
 					return -1;
 				}
@@ -448,11 +426,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		// Build an array of sessions with accessToken blanked
 		await globalState.update(
 			"authenticationProvider.strippedSessions",
-			this._sessions.map((session): StrippedSession => ({
-				id: session.id,
-				serverName: session.serverName,
-				server: session.auth.setting,
-			})),
+			this._sessions.map((session): StrippedSession => {
+				const { accessToken: _, ...strippedSession } = session;
+				return strippedSession;
+			}),
 		);
 	}
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -98,6 +98,20 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return serverName;
 	}
 
+	private async promptUserName(serverName: string) {
+		// Prompt for the username.
+		const enteredUserName = await window.showInputBox({
+			ignoreFocusOut: true,
+			placeHolder: `Username on server '${serverName}'`,
+			prompt: "Enter the username to access the InterSystems server with. Leave blank for unauthenticated access as 'UnknownUser'.",
+			title: `${AUTHENTICATION_PROVIDER_LABEL}: Username on InterSystems server '${serverName}'`,
+		});
+		if (enteredUserName === undefined) {
+			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Username is required.`);
+		}
+		return enteredUserName || "UnknownUser";
+	}
+
 	// This function is called after `this.getSessions` is called, and only when:
 	// - `this.getSessions` returns nothing but `createIfNone` was `true` in call to `vscode.authentication.getSession`
 	// - `vscode.authentication.getSession` was called with `forceNewSession: true` or
@@ -106,10 +120,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	public async createSession(scopes: string[]): Promise<AuthenticationSession> {
 		await this._ensureInitialized();
 
-		const serverName = scopes[0] ?? await this.promptServerName();
+		const serverName = scopes[0] || await this.promptServerName();
 		const spec = await getServerSpec(serverName);
-		let userName = scopes[1] ?? "";
-
 		if (spec?.authorization instanceof OAuth2Authorization) {
 			const token = await performOAuth2Login({
 				authority: spec.authorization.oauth2.authority,
@@ -121,20 +133,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 			return this._finalizeSession(serverName, "OAuth2User", token);
 		}
-
-		if (!userName) {
-			// Prompt for the username.
-			const enteredUserName = await window.showInputBox({
-				ignoreFocusOut: true,
-				placeHolder: `Username on server '${serverName}'`,
-				prompt: "Enter the username to access the InterSystems server with. Leave blank for unauthenticated access as 'UnknownUser'.",
-				title: `${AUTHENTICATION_PROVIDER_LABEL}: Username on InterSystems server '${serverName}'`,
-			});
-			if (typeof enteredUserName === "undefined") {
-				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Username is required.`);
-			}
-			userName = enteredUserName === "" ? "UnknownUser" : enteredUserName;
-		}
+		const userName = scopes[1] || await this.promptUserName(serverName);
 
 		// Return existing session if found
 		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -101,7 +101,22 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		await this._ensureInitialized();
 
 		const serverName = scopes[0] || await this.promptServerName();
-		const spec = await getServerSpec(serverName);
+		const spec = await getServerSpec(serverName)
+		const userName = scopes[1] || spec?.username || await this.promptUserName(serverName);
+		// Return existing session if found
+		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
+		const existingSession = this._sessions.find((s) => s.id === sessionId);
+		if (existingSession) {
+			if (this._checkedSessions.find((s) => s.id === sessionId)) {
+				return existingSession;
+			}
+
+			// Check if the session is still valid
+			if (await this._isStillValid(existingSession)) {
+				this._checkedSessions.push(existingSession);
+				return existingSession;
+			}
+		}
 		if (spec?.auth instanceof OAuth2Authorization) {
 			const accessToken = await performOAuth2Login({
 				authority: spec.auth.oauth2.authority,
@@ -115,21 +130,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
 			};
 		} else {
-			const userName = scopes[1] || await this.promptUserName(serverName);
-			// Return existing session if found
-			const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-			const existingSession = this._sessions.find((s) => s.id === sessionId);
-			if (existingSession) {
-				if (this._checkedSessions.find((s) => s.id === sessionId)) {
-					return existingSession;
-				}
-
-				// Check if the session is still valid
-				if (await this._isStillValid(existingSession)) {
-					this._checkedSessions.push(existingSession);
-					return existingSession;
-				}
-			}
 			const password = userName && await this.seekPassword(sessionId, userName, serverName);
 			const auth: Authorization = new PasswordAuthorization();
 			if (auth.resolve({ accessToken: password, username: userName || "UnknownUser" })) {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -185,7 +185,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (enteredUserName === undefined) {
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Username is required.`);
 		}
-		return enteredUserName;
+		return enteredUserName || "UnknownUser";
 	}
 
 	private async seekPassword(sessionId: string, userName: string, serverName: string): Promise<string> {
@@ -407,8 +407,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		const sessions = maybeSessions.filter((session) => session !== undefined) as ServerManagerAuthenticationSession[];
 		this._sessions = sessions
 			.sort((a, b) => {
-				const aUserNameLowercase = (a.userName || "").toLowerCase();
-				const bUserNameLowercase = (b.userName || "").toLowerCase();
+				const aUserNameLowercase = a.userName.toLowerCase();
+				const bUserNameLowercase = b.userName.toLowerCase();
 				if (aUserNameLowercase < bUserNameLowercase) {
 					return -1;
 				}
@@ -423,7 +423,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	}
 
 	private async _storeStrippedSessions() {
-		// Build an array of sessions with accessToken blanked
+		// Persist an array of sessions with accessToken blanked
 		await globalState.update(
 			"authenticationProvider.strippedSessions",
 			this._sessions.map((session): StrippedSession => {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -102,7 +102,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 		const serverName = scopes[0] || await this.promptServerName();
 		const spec = await getServerSpec(serverName)
-		const userName = scopes[1] || spec?.username || await this.promptUserName(serverName);
+		const userName = scopes[1] || spec?.auth.username || await this.promptUserName(serverName);
 		// Return existing session if found
 		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
 		const existingSession = this._sessions.find((s) => s.id === sessionId);

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -280,6 +280,11 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return true;
 	}
 
+	// This function is called when the end user signs out of the account.
+	public async removeSession(sessionId: string): Promise<void> {
+		this._removeSession(sessionId);
+	}
+
 	private async _removeSession(sessionId: string, alwaysDeletePassword = false): Promise<void> {
 		const index = this._sessions.findIndex((item) => item.id === sessionId);
 		const session = this._sessions[index];
@@ -315,11 +320,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		await this._storeStrippedSessions();
 		this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
-	}
-
-	// This function is called when the end user signs out of the account.
-	public async removeSession(sessionId: string): Promise<void> {
-		this._removeSession(sessionId);
 	}
 
 	public async removeSessions(sessionIds: string[]): Promise<void> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -84,6 +84,53 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return sessions || [];
 	}
 
+	// This function is called after `this.getSessions` is called, and only when:
+	// - `this.getSessions` returns nothing but `createIfNone` was `true` in call to `vscode.authentication.getSession`
+	// - `vscode.authentication.getSession` was called with `forceNewSession: true` or
+	//   `forceNewSession: {detail: "Reason message for modal dialog"}` (proposed API since 1.59, finalized in 1.63)
+	// - The end user initiates the "silent" auth flow via the Accounts menu
+	public async createSession(scopes: string[]): Promise<AuthenticationSession> {
+		await this._ensureInitialized();
+
+		const serverName = scopes[0] || await this.promptServerName();
+		const spec = await getServerSpec(serverName);
+		if (spec?.authorization instanceof OAuth2Authorization) {
+			const token = await performOAuth2Login({
+				authority: spec.authorization.oauth2.authority,
+				clientId: spec.authorization.oauth2.clientId,
+				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
+			});
+			if (!token) {
+				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
+			}
+			return this._finalizeSession(serverName, "OAuth2User", token);
+		}
+		const userName = scopes[1] || await this.promptUserName(serverName);
+
+		// Return existing session if found
+		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
+		const existingSession = this._sessions.find((s) => s.id === sessionId);
+		if (existingSession) {
+			if (this._checkedSessions.find((s) => s.id === sessionId)) {
+				return existingSession;
+			}
+
+			// Check if the session is still valid
+			if (await this._isStillValid(existingSession)) {
+				this._checkedSessions.push(existingSession);
+				return existingSession;
+			}
+		}
+		let password: string | undefined;
+		if (userName) {
+			// Seek password in secret storage
+			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+			password = await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
+		}
+
+		return this._finalizeSession(serverName, userName || "UnknownUser", password ?? "");
+	}
+
 	private async promptServerName(): Promise<string> {
 		if (!this._serverManagerExtension) {
 			throw new Error(`InterSystems Server Manager extension is not available to provide server selection for ${AUTHENTICATION_PROVIDER_LABEL}.`);
@@ -164,53 +211,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Password is required.`);
 		}
 		return password;
-	}
-
-	// This function is called after `this.getSessions` is called, and only when:
-	// - `this.getSessions` returns nothing but `createIfNone` was `true` in call to `vscode.authentication.getSession`
-	// - `vscode.authentication.getSession` was called with `forceNewSession: true` or
-	//   `forceNewSession: {detail: "Reason message for modal dialog"}` (proposed API since 1.59, finalized in 1.63)
-	// - The end user initiates the "silent" auth flow via the Accounts menu
-	public async createSession(scopes: string[]): Promise<AuthenticationSession> {
-		await this._ensureInitialized();
-
-		const serverName = scopes[0] || await this.promptServerName();
-		const spec = await getServerSpec(serverName);
-		if (spec?.authorization instanceof OAuth2Authorization) {
-			const token = await performOAuth2Login({
-				authority: spec.authorization.oauth2.authority,
-				clientId: spec.authorization.oauth2.clientId,
-				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
-			});
-			if (!token) {
-				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
-			}
-			return this._finalizeSession(serverName, "OAuth2User", token);
-		}
-		const userName = scopes[1] || await this.promptUserName(serverName);
-
-		// Return existing session if found
-		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-		const existingSession = this._sessions.find((s) => s.id === sessionId);
-		if (existingSession) {
-			if (this._checkedSessions.find((s) => s.id === sessionId)) {
-				return existingSession;
-			}
-
-			// Check if the session is still valid
-			if (await this._isStillValid(existingSession)) {
-				this._checkedSessions.push(existingSession);
-				return existingSession;
-			}
-		}
-		let password: string | undefined;
-		if (userName) {
-			// Seek password in secret storage
-			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-			password = await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
-		}
-
-		return this._finalizeSession(serverName, userName || "UnknownUser", password ?? "");
 	}
 
 	private async _finalizeSession(serverName: string, userName: string, password: string): Promise<AuthenticationSession> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -98,7 +98,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return serverName;
 	}
 
-	private async promptUserName(serverName: string) {
+	private async promptUserName(serverName: string): Promise<string> {
 		// Prompt for the username.
 		const enteredUserName = await window.showInputBox({
 			ignoreFocusOut: true,
@@ -109,7 +109,61 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (enteredUserName === undefined) {
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Username is required.`);
 		}
-		return enteredUserName || "UnknownUser";
+		return enteredUserName;
+	}
+
+	private async promptPassword(userName: string, serverName: string, credentialKey: string): Promise<string | undefined> {
+		const doInputBox = async (): Promise<string | undefined> => {
+			return await new Promise<string | undefined>((resolve, reject) => {
+				const inputBox = window.createInputBox();
+				inputBox.value = "";
+				inputBox.password = true;
+				inputBox.title = `${AUTHENTICATION_PROVIDER_LABEL}: Password for user '${userName}'`;
+				inputBox.placeholder = `Password for user '${userName}' on '${serverName}'`;
+				inputBox.prompt = "Optionally use $(key) button above to store password";
+				inputBox.ignoreFocusOut = true;
+				inputBox.buttons = [
+					{
+						iconPath: new ThemeIcon("key"),
+						tooltip: "Store Password Securely in Workstation Keychain",
+					},
+				];
+
+				async function done(secretStorage?: SecretStorage) {
+					// Return the password, having stored it if storage was passed
+					const enteredPassword = inputBox.value;
+					if (secretStorage && enteredPassword) {
+						await secretStorage.store(credentialKey, enteredPassword);
+					}
+					// Resolve the promise and tidy up
+					resolve(enteredPassword);
+					inputBox.dispose();
+				}
+
+				inputBox.onDidTriggerButton((_button) => {
+					// We only added the one button, which stores the password
+					done(this.secretStorage);
+				});
+
+				inputBox.onDidAccept(() => {
+					// User pressed Enter
+					done();
+				});
+
+				inputBox.onDidHide(() => {
+					// User pressed Escape
+					resolve(undefined);
+					inputBox.dispose();
+				});
+
+				inputBox.show();
+			});
+		};
+		const password = await doInputBox();
+		if (!password) {
+			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Password is required.`);
+		}
+		return password;
 	}
 
 	// This function is called after `this.getSessions` is called, and only when:
@@ -149,69 +203,14 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				return existingSession;
 			}
 		}
-
 		let password: string | undefined;
-
-		if (userName !== "UnknownUser") {
+		if (userName) {
 			// Seek password in secret storage
 			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-			password = await this.secretStorage.get(credentialKey);
-			if (!password) {
-				// Prompt for password
-				const doInputBox = async (): Promise<string | undefined> => {
-					return await new Promise<string | undefined>((resolve, reject) => {
-						const inputBox = window.createInputBox();
-						inputBox.value = "";
-						inputBox.password = true;
-						inputBox.title = `${AUTHENTICATION_PROVIDER_LABEL}: Password for user '${userName}'`;
-						inputBox.placeholder = `Password for user '${userName}' on '${serverName}'`;
-						inputBox.prompt = "Optionally use $(key) button above to store password";
-						inputBox.ignoreFocusOut = true;
-						inputBox.buttons = [
-							{
-								iconPath: new ThemeIcon("key"),
-								tooltip: "Store Password Securely in Workstation Keychain",
-							},
-						];
-
-						async function done(secretStorage?: SecretStorage) {
-							// Return the password, having stored it if storage was passed
-							const enteredPassword = inputBox.value;
-							if (secretStorage && enteredPassword) {
-								await secretStorage.store(credentialKey, enteredPassword);
-							}
-							// Resolve the promise and tidy up
-							resolve(enteredPassword);
-							inputBox.dispose();
-						}
-
-						inputBox.onDidTriggerButton((_button) => {
-							// We only added the one button, which stores the password
-							done(this.secretStorage);
-						});
-
-						inputBox.onDidAccept(() => {
-							// User pressed Enter
-							done();
-						});
-
-						inputBox.onDidHide(() => {
-							// User pressed Escape
-							resolve(undefined);
-							inputBox.dispose();
-						});
-
-						inputBox.show();
-					});
-				};
-				password = await doInputBox();
-				if (!password) {
-					throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Password is required.`);
-				}
-			}
+			password = await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
 		}
 
-		return this._finalizeSession(serverName, userName, password ?? "");
+		return this._finalizeSession(serverName, userName || "UnknownUser", password ?? "");
 	}
 
 	private async _finalizeSession(serverName: string, userName: string, password: string): Promise<AuthenticationSession> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -14,7 +14,7 @@ import {
 	workspace,
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
-import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
+import { globalState, OAuth2Authorization } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
@@ -106,7 +106,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return this._finalizeSession(serverName, "OAuth2User", token);
 		}
 		const userName = scopes[1] || await this.promptUserName(serverName);
-
 		// Return existing session if found
 		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
 		const existingSession = this._sessions.find((s) => s.id === sessionId);
@@ -121,14 +120,14 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				return existingSession;
 			}
 		}
-		let password: string | undefined;
-		if (userName) {
-			// Seek password in secret storage
-			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-			password = await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
-		}
-
+		const password = userName && await this.seekPassword(sessionId, userName, serverName);
 		return this._finalizeSession(serverName, userName || "UnknownUser", password ?? "");
+	}
+
+	// Seek password in secret storage
+	private async seekPassword(sessionId: string, userName: string, serverName: string): Promise<string | undefined> {
+		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+		return await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
 	}
 
 	private async promptServerName(): Promise<string> {
@@ -238,8 +237,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return true;
 		}
 		const serverSpec = await getServerSpec(session.serverName);
-		if (serverSpec?.authorization instanceof PasswordAuthorization) {
-			serverSpec.authorization = new PasswordAuthorization(session.userName, session.accessToken);
+		if (serverSpec) {
+			serverSpec.authorization.resolve(session.accessToken, session.userName);
 			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -5,7 +5,6 @@ import {
 	AuthenticationProviderAuthenticationSessionsChangeEvent,
 	AuthenticationProviderSessionOptions,
 	AuthenticationSession,
-	ConfigurationTarget,
 	Disposable,
 	Event,
 	EventEmitter,

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -18,7 +18,7 @@ import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commo
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
-import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
+import { Authorization, IServerSpec, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -242,11 +242,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (this._checkedSessions.find((s) => s.id === session.id)) {
 			return true;
 		}
-		const serverSpec = await getServerSpec(session.serverName);
+		const serverSpec: IServerSpec | undefined = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			const auth: Authorization = serverSpec.authorization;
-			auth.resolve(session.accessToken, session.userName);
-			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
+			const response = await makeRESTRequest("HEAD", { ...serverSpec, authorization: session.authorization }).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -14,19 +14,13 @@ import {
 	window,
 	workspace,
 } from "vscode";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
-import { IOAuth2Config, performOAuth2Login } from "./oauth2Flow";
+import { performOAuth2Login } from "./oauth2Flow";
 import { promptOAuth2Authority, promptOAuth2ClientId } from "./oauth2Prompts";
-
-/** Extended server spec with OAuth2 support (internal only) */
-interface IServerSpecOAuth2 extends IServerSpec {
-	authMethod?: "password" | "oauth2";
-	oauth2?: IOAuth2Config;
-}
+import { IServerSpec, OAuth2IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -117,7 +111,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 
 		// Check auth method early to branch the flow
-		const serverSpec = await getServerSpec(serverName) as IServerSpecOAuth2 | undefined;
+		const serverSpec = await getServerSpec(serverName) as IServerSpec | undefined;
 
 		if (serverSpec?.authMethod === "oauth2") {
 			return this._createOAuth2Session(serverName, serverSpec);
@@ -125,10 +119,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return this._createPasswordSession(serverName, scopes[1] ?? "");
 		}
 	}
-
-	private async _createOAuth2Session(serverName: string, serverSpec: IServerSpecOAuth2): Promise<AuthenticationSession> {
-		const userName = "OAuth2User";
-
+	private async _createOAuth2Session(serverName: string, serverSpec: OAuth2IServerSpec): Promise<AuthenticationSession> {
 		// Resolve OAuth2 config — prompt for missing values
 		const oauth2Config = await resolveOAuth2Config(serverName, serverSpec);
 		if (!oauth2Config) {
@@ -142,7 +133,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 
 		// Token is stored as the session's accessToken (password field) and sent as Bearer token
-		return this._finalizeSession(serverName, userName, token);
+		return this._finalizeSession(serverName, serverSpec.username, token);
 	}
 
 	private async _createPasswordSession(serverName: string, scopeUserName: string): Promise<AuthenticationSession> {
@@ -265,7 +256,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return true;
 		}
 		const serverSpec = await getServerSpec(session.serverName);
-		if (serverSpec) {
+		if (serverSpec && serverSpec.authMethod !== "oauth2") {
 			serverSpec.username = session.userName;
 			serverSpec.password = session.accessToken;
 			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
@@ -457,10 +448,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
  */
 async function resolveOAuth2Config(
 	serverName: string,
-	serverSpec: IServerSpecOAuth2,
+	serverSpec: OAuth2IServerSpec,
 ): Promise<{ authority: string; clientId: string; audience: string; scopes?: string[] } | undefined> {
 
-	const existing = serverSpec.oauth2;
+	const existing: Partial<OAuth2IServerSpec["oauth2"]> = serverSpec.oauth2;
 	const config = workspace.getConfiguration("intersystems.servers");
 
 	// Authority

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -175,7 +175,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 
 		// Token is stored as the session's accessToken (password field) and sent as Bearer token
-		return this._finalizeSession(serverName, serverSpec.username, token);
+		return this._finalizeSession(serverName, serverSpec.username || "OAuth2User", token);
 	}
 
 	private async _createPasswordSession(serverName: string, scopeUserName: string): Promise<AuthenticationSession> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -95,16 +95,16 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 		const serverName = scopes[0] || await this.promptServerName();
 		const spec = await getServerSpec(serverName);
-		if (spec?.authorization instanceof OAuth2Authorization) {
+		if (spec?.auth instanceof OAuth2Authorization) {
 			const token = await performOAuth2Login({
-				authority: spec.authorization.oauth2.authority,
-				clientId: spec.authorization.oauth2.clientId,
+				authority: spec.auth.oauth2.authority,
+				clientId: spec.auth.oauth2.clientId,
 				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
 			});
 			if (!token) {
 				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
 			}
-			const auth: Authorization = new OAuth2Authorization(spec.authorization.oauth2);
+			const auth: Authorization = new OAuth2Authorization(spec.auth.oauth2);
 			auth.resolve(token, "OAuth2User");
 			return this._finalizeSession(serverName, auth);
 		} else {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -4,6 +4,7 @@ import {
 	AuthenticationProviderAuthenticationSessionsChangeEvent,
 	AuthenticationProviderSessionOptions,
 	AuthenticationSession,
+	ConfigurationTarget,
 	Disposable,
 	Event,
 	EventEmitter,
@@ -13,10 +14,19 @@ import {
 	window,
 	workspace,
 } from "vscode";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
+import { IOAuth2Config, performOAuth2Login } from "./oauth2Flow";
+import { promptOAuth2Audience, promptOAuth2Authority, promptOAuth2ClientId } from "./oauth2Prompts";
+
+/** Extended server spec with OAuth2 support (internal only) */
+interface IServerSpecOAuth2 extends IServerSpec {
+	authMethod?: "password" | "oauth2";
+	oauth2?: IOAuth2Config;
+}
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -106,7 +116,37 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 		}
 
-		let userName = scopes[1] ?? "";
+		// Check auth method early to branch the flow
+		const serverSpec = await getServerSpec(serverName) as IServerSpecOAuth2 | undefined;
+
+		if (serverSpec?.authMethod === "oauth2") {
+			return this._createOAuth2Session(serverName, serverSpec);
+		} else {
+			return this._createPasswordSession(serverName, scopes[1] ?? "");
+		}
+	}
+
+	private async _createOAuth2Session(serverName: string, serverSpec: IServerSpecOAuth2): Promise<AuthenticationSession> {
+		const userName = serverSpec.username || "OAuth2User";
+
+		// Resolve OAuth2 config — prompt for missing values
+		const oauth2Config = await resolveOAuth2Config(serverName, serverSpec);
+		if (!oauth2Config) {
+			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 configuration is required.`);
+		}
+
+		// Perform OAuth2 login flow (opens browser, gets JWT)
+		const token = await performOAuth2Login(oauth2Config);
+		if (!token) {
+			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
+		}
+
+		// Token is stored as the session's accessToken (password field) and sent as Bearer token
+		return this._finalizeSession(serverName, userName, token);
+	}
+
+	private async _createPasswordSession(serverName: string, scopeUserName: string): Promise<AuthenticationSession> {
+		let userName = scopeUserName;
 		if (!userName) {
 			// Prompt for the username.
 			const enteredUserName = await window.showInputBox({
@@ -123,7 +163,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 		// Return existing session if found
 		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-		let existingSession = this._sessions.find((s) => s.id === sessionId);
+		const existingSession = this._sessions.find((s) => s.id === sessionId);
 		if (existingSession) {
 			if (this._checkedSessions.find((s) => s.id === sessionId)) {
 				return existingSession;
@@ -136,7 +176,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 		}
 
-		let password: string | undefined = "";
+		let password: string | undefined;
 
 		if (userName !== "UnknownUser") {
 			// Seek password in secret storage
@@ -197,6 +237,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 		}
 
+		return this._finalizeSession(serverName, userName, password ?? "");
+	}
+
+	private async _finalizeSession(serverName: string, userName: string, password: string): Promise<AuthenticationSession> {
 		// We have all we need to create the session object
 		const session = new ServerManagerAuthenticationSession(serverName, userName, password);
 		// Update this._sessions and raise the event to notify
@@ -236,11 +280,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return true;
 	}
 
-	// This function is called when the end user signs out of the account.
-	public async removeSession(sessionId: string): Promise<void> {
-		this._removeSession(sessionId);
-	}
-
 	private async _removeSession(sessionId: string, alwaysDeletePassword = false): Promise<void> {
 		const index = this._sessions.findIndex((item) => item.id === sessionId);
 		const session = this._sessions[index];
@@ -278,6 +317,11 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
 	}
 
+	// This function is called when the end user signs out of the account.
+	public async removeSession(sessionId: string): Promise<void> {
+		this._removeSession(sessionId);
+	}
+
 	public async removeSessions(sessionIds: string[]): Promise<void> {
 		const storedPasswordCredKeys: string[] = [];
 		const removed: AuthenticationSession[] = [];
@@ -302,7 +346,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 					`Do you want to keep the stored passwords or delete them?`,
 					{
 						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
-							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true
+							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
 					},
 					{ title: "Keep", isCloseAffordance: true },
 					{ title: "Delete", isCloseAffordance: false },
@@ -404,4 +448,51 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			strippedSessions,
 		);
 	}
+}
+
+/**
+ * Resolve OAuth2 configuration for a server, prompting for any missing values.
+ * If the user cancels any prompt, returns undefined.
+ * Persists each value to settings immediately so progress isn't lost.
+ */
+async function resolveOAuth2Config(
+	serverName: string,
+	serverSpec: IServerSpecOAuth2,
+): Promise<{ authority: string; clientId: string; audience: string; scopes?: string[] } | undefined> {
+
+	const existing = serverSpec.oauth2;
+	const config = workspace.getConfiguration("intersystems.servers");
+
+	// Authority
+	let authority = existing?.authority;
+	if (!authority) {
+		authority = await promptOAuth2Authority(serverName);
+		if (!authority) { return undefined; }
+		const sc = config.get<any>(serverName) || {};
+		sc.oauth2 = { ...sc.oauth2, authority };
+		await config.update(serverName, sc, ConfigurationTarget.Global);
+	}
+
+	// Client ID
+	let clientId = existing?.clientId;
+	if (!clientId) {
+		clientId = await promptOAuth2ClientId(serverName);
+		if (!clientId) { return undefined; }
+		const sc = config.get<any>(serverName) || {};
+		sc.oauth2 = { ...sc.oauth2, clientId };
+		await config.update(serverName, sc, ConfigurationTarget.Global);
+	}
+
+	// Audience
+	let audience = existing?.audience;
+	if (!audience) {
+		const defaultAudience = `${serverSpec.webServer.scheme || "http"}://${serverSpec.webServer.host}:${serverSpec.webServer.port}/`;
+		audience = await promptOAuth2Audience(serverName, defaultAudience);
+		if (!audience) { return undefined; }
+		const sc = config.get<any>(serverName) || {};
+		sc.oauth2 = { ...sc.oauth2, audience };
+		await config.update(serverName, sc, ConfigurationTarget.Global);
+	}
+
+	return { authority, clientId, audience };
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -108,11 +108,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 		}
 
-		const serverSpec = await getServerSpec(serverName);
-		return this._createSession(serverName, scopes[1] ?? "", serverSpec);
-	}
+		const spec = await getServerSpec(serverName);
+		let userName = scopes[1] ?? "";
 
-	private async _createSession(serverName: string, scopeUserName: string, spec?: IServerSpec): Promise<AuthenticationSession> {
 		if (spec?.authorization instanceof OAuth2Authorization) {
 			const token = await performOAuth2Login({
 				authority: spec.authorization.oauth2.authority,
@@ -125,7 +123,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return this._finalizeSession(serverName, "OAuth2User", token);
 		}
 
-		let userName = scopeUserName;
 		if (!userName) {
 			// Prompt for the username.
 			const enteredUserName = await window.showInputBox({

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -1,4 +1,3 @@
-import { OAuth2IServerSetting } from "./serverSetting";
 import {
 	authentication,
 	AuthenticationProvider,
@@ -15,10 +14,11 @@ import {
 	workspace,
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
-import { globalState } from "./commonActivate";
-import { getServerSetting } from "./api/getServerSpec";
+import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
+import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -108,14 +108,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			}
 		}
 
-		// Check auth method early to branch the flow
-		const serverSetting = await getServerSetting(serverName);
-
-		if (serverSetting && 'oauth2' in serverSetting) {
-			return this._createOAuth2Session(serverName, serverSetting);
-		} else {
-			return this._createPasswordSession(serverName, scopes[1] ?? "");
-		}
+		const serverSpec = await getServerSpec(serverName);
+		return this._createSession(serverName, scopes[1] ?? "", serverSpec);
 	}
 
 	// This function is called when the end user signs out of the account.
@@ -161,24 +155,20 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		await this._storeStrippedSessions();
 		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
 	}
-	private async _createOAuth2Session(serverName: string, serverSetting: OAuth2IServerSetting): Promise<AuthenticationSession> {
-		// Resolve OAuth2 config — prompt for missing values
-		const oauth2Config = await resolveOAuth2Config(serverSetting);
-		if (!oauth2Config) {
-			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 configuration is required.`);
+
+	private async _createSession(serverName: string, scopeUserName: string, spec?: IServerSpec): Promise<AuthenticationSession> {
+		if (spec?.authorization instanceof OAuth2Authorization) {
+			const token = await performOAuth2Login({
+				authority: spec.authorization.oauth2.authority,
+				clientId: spec.authorization.oauth2.clientId,
+				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
+			});
+			if (!token) {
+				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
+			}
+			return this._finalizeSession(serverName, "OAuth2User", token);
 		}
 
-		// Perform OAuth2 login flow (opens browser, gets JWT)
-		const token = await performOAuth2Login(oauth2Config);
-		if (!token) {
-			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: OAuth2 login failed or was cancelled.`);
-		}
-
-		// Token is stored as the session's accessToken (password field) and sent as Bearer token
-		return this._finalizeSession(serverName, "OAuth2User", token);
-	}
-
-	private async _createPasswordSession(serverName: string, scopeUserName: string): Promise<AuthenticationSession> {
 		let userName = scopeUserName;
 		if (!userName) {
 			// Prompt for the username.
@@ -297,11 +287,10 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (this._checkedSessions.find((s) => s.id === session.id)) {
 			return true;
 		}
-		const serverSetting = await getServerSetting(session.serverName);
-		if (serverSetting && !('oauth2' in serverSetting)) {
-			serverSetting.username = session.userName;
-			serverSetting.password = session.accessToken;
-			const response = await makeRESTRequest("HEAD", serverSetting).catch(() => { /* Swallow errors */ });
+		const serverSpec = await getServerSpec(session.serverName);
+		if (serverSpec?.authorization instanceof PasswordAuthorization) {
+			serverSpec.authorization = new PasswordAuthorization(session.userName, session.accessToken);
+			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;
@@ -437,15 +426,4 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			strippedSessions,
 		);
 	}
-}
-
-/**
- * Resolve OAuth2 configuration for a server, prompting for any missing values.
- * If the user cancels any prompt, returns undefined.
- * Persists each value to settings immediately so progress isn't lost.
- */
-async function resolveOAuth2Config(
-	serverSetting: OAuth2IServerSetting,
-): Promise<{ authority: string; clientId: string; audience: string; scopes?: string[] } | undefined> {
-	return { authority: serverSetting.oauth2.authority, clientId: serverSetting.oauth2.clientId, audience: `${serverSetting.webServer.scheme || "http"}://${serverSetting.webServer.host}:${serverSetting.webServer.port}/` };
 }

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -18,7 +18,6 @@ import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commo
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -85,6 +84,20 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return sessions || [];
 	}
 
+	private async promptServerName(): Promise<string> {
+		if (!this._serverManagerExtension) {
+			throw new Error(`InterSystems Server Manager extension is not available to provide server selection for ${AUTHENTICATION_PROVIDER_LABEL}.`);
+		}
+		if (!this._serverManagerExtension.isActive) {
+			await this._serverManagerExtension.activate();
+		}
+		const serverName = await this._serverManagerExtension.exports.pickServer() ?? "";
+		if (!serverName) {
+			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Server name is required.`);
+		}
+		return serverName;
+	}
+
 	// This function is called after `this.getSessions` is called, and only when:
 	// - `this.getSessions` returns nothing but `createIfNone` was `true` in call to `vscode.authentication.getSession`
 	// - `vscode.authentication.getSession` was called with `forceNewSession: true` or
@@ -93,21 +106,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	public async createSession(scopes: string[]): Promise<AuthenticationSession> {
 		await this._ensureInitialized();
 
-		let serverName = scopes[0] ?? "";
-		if (!serverName) {
-			// Prompt for the server name.
-			if (!this._serverManagerExtension) {
-				throw new Error(`InterSystems Server Manager extension is not available to provide server selection for ${AUTHENTICATION_PROVIDER_LABEL}.`);
-			}
-			if (!this._serverManagerExtension.isActive) {
-				await this._serverManagerExtension.activate();
-			}
-			serverName = await this._serverManagerExtension.exports.pickServer() ?? "";
-			if (!serverName) {
-				throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Server name is required.`);
-			}
-		}
-
+		const serverName = scopes[0] ?? await this.promptServerName();
 		const spec = await getServerSpec(serverName);
 		let userName = scopes[1] ?? "";
 

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -1,3 +1,4 @@
+import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 import {
 	authentication,
 	AuthenticationProvider,
@@ -13,12 +14,11 @@ import {
 	window,
 	workspace,
 } from "vscode";
+import { getServerSpec } from "./api/getServerSpec";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
-import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
-import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -31,6 +31,9 @@ interface StrippedSession {
 }
 
 export class ServerManagerAuthenticationProvider implements AuthenticationProvider, Disposable {
+	get onDidChangeSessions(): Event<AuthenticationProviderAuthenticationSessionsChangeEvent> {
+		return this._onDidChangeSessions.event;
+	}
 	public static id = AUTHENTICATION_PROVIDER;
 	public static label = AUTHENTICATION_PROVIDER_LABEL;
 	public static secretKeyPrefix = "credentialProvider:";
@@ -52,9 +55,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	private _serverManagerExtension = extensions.getExtension("intersystems-community.servermanager");
 
 	private _onDidChangeSessions = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
-	get onDidChangeSessions(): Event<AuthenticationProviderAuthenticationSessionsChangeEvent> {
-		return this._onDidChangeSessions.event;
-	}
 
 	constructor(private readonly secretStorage: SecretStorage) {
 		this._secretStorage = secretStorage;
@@ -78,7 +78,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (options.account) {
 			const accountParts = options.account.id.split("/");
 			const serverName = accountParts.shift();
-			const userName = accountParts.join('/');
+			const userName = accountParts.join("/");
 			if (serverName && userName) {
 				sessions = sessions.filter((session) => session.scopes[0] === serverName && session.scopes[1].toLowerCase() === userName.toLowerCase());
 			}
@@ -101,7 +101,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		await this._ensureInitialized();
 
 		const serverName = scopes[0] || await this.promptServerName();
-		const spec = await getServerSpec(serverName)
+		const spec = await getServerSpec(serverName);
 		const userName = scopes[1] || spec?.auth.username || await this.promptUserName(serverName);
 		// Return existing session if found
 		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
@@ -120,7 +120,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 					accessToken = await performOAuth2Login({
 						authority: spec?.auth.oauth2.authority,
 						clientId: spec?.auth.oauth2.clientId,
-						audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
+						audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`,
 					});
 					if (this.secretStorage && accessToken) {
 						await this.secretStorage?.store(credentialKey, accessToken);
@@ -132,13 +132,57 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 			}
 			auth = spec?.auth.clone() ?? new PasswordAuthorization();
-			auth.resolve({ username: userName || "UnknownUser", accessToken })
+			auth.resolve({ username: userName || "UnknownUser", accessToken });
 		}
 		if (auth.resolved()) {
 			return this._finalizeSession(serverName, auth);
 		} else {
 			throw new Error("Internal error: Authorization should already be resolved");
-		};
+		}
+	}
+
+	// This function is called when the end user signs out of the account.
+	public async removeSession(sessionId: string): Promise<void> {
+		this._removeSession(sessionId);
+	}
+
+	public async removeSessions(sessionIds: string[]): Promise<void> {
+		const storedPasswordCredKeys: string[] = [];
+		const removed: AuthenticationSession[] = [];
+		await Promise.allSettled(sessionIds.map(async (sessionId) => {
+			const index = this._sessions.findIndex((item) => item.id === sessionId);
+			const session = this._sessions[index];
+			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+			if (await this.secretStorage.get(credentialKey) !== undefined) {
+				storedPasswordCredKeys.push(credentialKey);
+			}
+			if (index > -1) {
+				this._sessions.splice(index, 1);
+			}
+			removed.push(session);
+		}));
+		if (storedPasswordCredKeys.length) {
+			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
+				.get<string>("deletePasswordOnSignout", "ask");
+			let deletePasswords = (passwordOption === "always");
+			if (passwordOption === "ask") {
+				const choice = await window.showWarningMessage(
+					`Do you want to keep the stored passwords or delete them?`,
+					{
+						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
+							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
+					},
+					{ title: "Keep", isCloseAffordance: true },
+					{ title: "Delete", isCloseAffordance: false },
+				);
+				deletePasswords = (choice?.title === "Delete");
+			}
+			if (deletePasswords) {
+				await Promise.allSettled(storedPasswordCredKeys.map((e) => this.secretStorage.delete(e)));
+			}
+		}
+		await this._storeStrippedSessions();
+		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
 	}
 
 	private async promptServerName(): Promise<string> {
@@ -264,7 +308,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			serverSpec.auth.resolve({ accessToken: session.accessToken, username: session.userName })
+			serverSpec.auth.resolve({ accessToken: session.accessToken, username: session.userName });
 			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
@@ -275,11 +319,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		this._checkedSessions.push(session);
 		return true;
-	}
-
-	// This function is called when the end user signs out of the account.
-	public async removeSession(sessionId: string): Promise<void> {
-		this._removeSession(sessionId);
 	}
 
 	private async _removeSession(sessionId: string, alwaysDeletePassword = false): Promise<void> {
@@ -319,45 +358,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
 	}
 
-	public async removeSessions(sessionIds: string[]): Promise<void> {
-		const storedPasswordCredKeys: string[] = [];
-		const removed: AuthenticationSession[] = [];
-		await Promise.allSettled(sessionIds.map(async (sessionId) => {
-			const index = this._sessions.findIndex((item) => item.id === sessionId);
-			const session = this._sessions[index];
-			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-			if (await this.secretStorage.get(credentialKey) !== undefined) {
-				storedPasswordCredKeys.push(credentialKey);
-			}
-			if (index > -1) {
-				this._sessions.splice(index, 1);
-			}
-			removed.push(session);
-		}));
-		if (storedPasswordCredKeys.length) {
-			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
-				.get<string>("deletePasswordOnSignout", "ask");
-			let deletePasswords = (passwordOption === "always");
-			if (passwordOption === "ask") {
-				const choice = await window.showWarningMessage(
-					`Do you want to keep the stored passwords or delete them?`,
-					{
-						detail: `${storedPasswordCredKeys.length == sessionIds.length ? "All" : "Some"
-							} of the ${AUTHENTICATION_PROVIDER_LABEL} accounts you signed out are currently storing their passwords securely on your workstation.`, modal: true,
-					},
-					{ title: "Keep", isCloseAffordance: true },
-					{ title: "Delete", isCloseAffordance: false },
-				);
-				deletePasswords = (choice?.title === "Delete");
-			}
-			if (deletePasswords) {
-				await Promise.allSettled(storedPasswordCredKeys.map((e) => this.secretStorage.delete(e)));
-			}
-		}
-		await this._storeStrippedSessions();
-		this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
-	}
-
 	private async _ensureInitialized(): Promise<void> {
 		if (this._initializedDisposable === undefined) {
 
@@ -383,7 +383,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 									this._sessions[index] = new ServerManagerAuthenticationSession(
 										session.serverName,
 										session.userName,
-										password
+										password,
 									);
 								}
 							}
@@ -410,7 +410,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
 				const accessToken = await this._secretStorage.get(credentialKey);
-				if (accessToken === undefined) return [];
+				if (accessToken === undefined) { return []; }
 				return [new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken)];
 			})))
 			.flat(1)

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -16,7 +16,7 @@ import {
 } from "vscode";
 import { getServerSpec } from "./api/getServerSpec";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
-import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
+import { globalState, OAuth2Authorization, BasicAuthorization } from "./commonActivate";
 import { logger } from "./logger";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { IOAuth2Config, performOAuth2Login, refreshOAuth2Token } from "./oauth2Flow";
@@ -77,7 +77,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 	private _onDidChangeSessions = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
 
-	constructor(private readonly secretStorage: SecretStorage) {}
+	constructor(private readonly secretStorage: SecretStorage) { }
 
 	public dispose(): void {
 
@@ -148,7 +148,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				}
 
 			}
-			auth = spec?.auth.clone() ?? new PasswordAuthorization();
+			auth = spec?.auth.clone() ?? new BasicAuthorization();
 			auth.resolve({ username: userName || "UnknownUser", accessToken });
 		}
 		if (auth.resolved()) {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -14,10 +14,11 @@ import {
 	workspace,
 } from "vscode";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
-import { Authorization, globalState, OAuth2Authorization, PasswordAuthorization, ResolvedAuthorization } from "./commonActivate";
+import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
+import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -72,7 +72,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 		// Filter to return only those that match all supplied scopes, which are positional and case-insensitive.
 		for (let index = 0; index < scopes.length; index++) {
-			sessions = sessions.filter((session) => session.scopes[index]?.toLowerCase() === scopes[index]?.toLowerCase());
+			sessions = sessions.filter((session) => session.scopes[index].toLowerCase() === scopes[index].toLowerCase());
 		}
 
 		if (options.account) {
@@ -80,7 +80,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			const serverName = accountParts.shift();
 			const userName = accountParts.join('/');
 			if (serverName && userName) {
-				sessions = sessions.filter((session) => session.scopes[0] === serverName && session.scopes[1]?.toLowerCase() === userName.toLowerCase());
+				sessions = sessions.filter((session) => session.scopes[0] === serverName && session.scopes[1].toLowerCase() === userName.toLowerCase());
 			}
 		}
 

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -18,7 +18,6 @@ import { Authorization, globalState, OAuth2Authorization, PasswordAuthorization,
 import { getServerSpec } from "./api/getServerSpec";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { performOAuth2Login } from "./oauth2Flow";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -255,7 +254,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (this._checkedSessions.find((s) => s.id === session.id)) {
 			return true;
 		}
-		const serverSpec: IServerSpec | undefined = await getServerSpec(session.serverName);
+		const serverSpec = await getServerSpec(session.serverName);
 		if (serverSpec) {
 			const auth = serverSpec.auth.clone();
 			auth.resolve({ accessToken: session.accessToken })

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -256,9 +256,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			const auth = serverSpec.auth.clone();
-			auth.resolve({ accessToken: session.accessToken })
-			const response = await makeRESTRequest("HEAD", { ...serverSpec, auth }).catch(() => { /* Swallow errors */ });
+			serverSpec.auth.resolve({ accessToken: session.accessToken })
+			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);
 				return false;

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -105,17 +105,9 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		const userName = scopes[1] || spec?.auth.username || await this.promptUserName(serverName);
 		// Return existing session if found
 		const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-		const existingSession = this._sessions.find((s) => s.id === sessionId);
-		if (existingSession) {
-			if (this._checkedSessions.find((s) => s.id === sessionId)) {
-				return existingSession;
-			}
-
-			// Check if the session is still valid
-			if (await this._isStillValid(existingSession)) {
-				this._checkedSessions.push(existingSession);
-				return existingSession;
-			}
+		const existingSession = await this.findExistingSession(sessionId);
+		if (existingSession !== undefined) {
+			return existingSession;
 		}
 		let auth: Authorization;
 		if (spec?.auth instanceof OAuth2Authorization) {
@@ -182,6 +174,21 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Username is required.`);
 		}
 		return enteredUserName || "UnknownUser";
+	}
+
+	private async findExistingSession(sessionId: string): Promise<AuthenticationSession | undefined> {
+		const existingSession = this._sessions.find((s) => s.id === sessionId);
+		if (existingSession) {
+			if (this._checkedSessions.find((s) => s.id === sessionId)) {
+				return existingSession;
+			}
+
+			// Check if the session is still valid
+			if (await this._isStillValid(existingSession)) {
+				this._checkedSessions.push(existingSession);
+				return existingSession;
+			}
+		}
 	}
 
 	private async seekPassword(sessionId: string, userName: string, serverName: string): Promise<string> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -17,7 +17,7 @@ import {
 import { getServerSpec } from "./api/getServerSpec";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
-import { log } from "./logger";
+import { logger } from "./logger";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
 import { IOAuth2Config, performOAuth2Login, refreshOAuth2Token } from "./oauth2Flow";
 
@@ -140,7 +140,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 					if (accessToken) {
 						await this.secretStorage.store(credentialKey, accessToken);
 						await this._storeOAuth2Secret(sessionId, tokenSet);
-						log(`OAuth2 [${sessionId}]: login complete, ${tokenSet?.refreshToken ? "refresh token stored" : "no refresh token"}`);
+						logger?.info(`OAuth2 [${sessionId}]: login complete, ${tokenSet?.refreshToken ? "refresh token stored" : "no refresh token"}`);
 					}
 				} else {
 					// Password is "" if userName is ""
@@ -337,17 +337,17 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			const isOAuth2 = serverSpec.auth instanceof OAuth2Authorization;
 			// Proactively renew an expired OAuth2 access token so we don't send a request we know will fail
 			if (isOAuth2 && await this._isAccessTokenExpired(session.id)) {
-				log(`OAuth2 [${session.id}]: access token expired, refreshing proactively`);
+				logger?.debug(`OAuth2 [${session.id}]: access token expired, refreshing proactively`);
 				session = await this._tryRefresh(session, serverSpec) ?? session;
 			}
 			serverSpec.auth.resolve({ accessToken: session.accessToken, username: session.userName });
 			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => undefined);
 			if (response?.status == 401) {
 				// Before giving up and forcing an interactive login, try to renew via refresh token
-				if (isOAuth2) { log(`OAuth2 [${session.id}]: got 401, attempting refresh`); }
+				if (isOAuth2) { logger?.debug(`OAuth2 [${session.id}]: got 401, attempting refresh`); }
 				const refreshed = isOAuth2 ? await this._tryRefresh(session, serverSpec) : undefined;
 				if (!refreshed) {
-					if (isOAuth2) { log(`OAuth2 [${session.id}]: refresh unavailable, signing out (re-login required)`); }
+					if (isOAuth2) { logger?.warn(`OAuth2 [${session.id}]: refresh unavailable, signing out (re-login required)`); }
 					await this._removeSession(session.id, true);
 					return false;
 				}
@@ -397,7 +397,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	private async _doRefresh(sessionId: string, serverSpec: IServerSpecWithAuth): Promise<string | undefined> {
 		const secret = await this._getOAuth2Secret(sessionId);
 		if (!secret?.refreshToken) {
-			log(`OAuth2 [${sessionId}]: no refresh token stored`);
+			logger?.debug(`OAuth2 [${sessionId}]: no refresh token stored`);
 			return undefined;
 		}
 		const tokenSet = await refreshOAuth2Token(sessionId, ServerManagerAuthenticationProvider.oauth2Config(serverSpec), secret.refreshToken);
@@ -405,7 +405,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
 		await this.secretStorage.store(credentialKey, tokenSet.accessToken);
 		await this._storeOAuth2Secret(sessionId, tokenSet);
-		log(`OAuth2 [${sessionId}]: access token refreshed successfully`);
+		logger?.info(`OAuth2 [${sessionId}]: access token refreshed successfully`);
 		return tokenSet.accessToken;
 	}
 

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -132,7 +132,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 			}
 			auth = spec?.auth.clone() ?? new PasswordAuthorization();
-			auth.resolve({ username: userName, accessToken })
+			auth.resolve({ username: userName || "UnknownUser", accessToken })
 		}
 		if (auth.resolved()) {
 			return this._finalizeSession(serverName, auth);
@@ -166,7 +166,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		if (enteredUserName === undefined) {
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Username is required.`);
 		}
-		return enteredUserName || "UnknownUser";
+		return enteredUserName;
 	}
 
 	private async findExistingSession(sessionId: string): Promise<AuthenticationSession | undefined> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -398,17 +398,14 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			[],
 		);
 		// Build our array of sessions for which non-empty accessTokens were securely persisted
-		const maybeSessions = await Promise.all(
+		this._sessions = (await Promise.all(
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
 				const accessToken = await this._secretStorage.get(credentialKey);
-				if (accessToken !== undefined) {
-					return new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken);
-				}
-			})
-		);
-		const sessions = maybeSessions.filter((session) => session !== undefined) as ServerManagerAuthenticationSession[];
-		this._sessions = sessions
+				if (accessToken === undefined) return [];
+				return [new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken)];
+			})))
+			.flat(1)
 			.sort((a, b) => {
 				const aUserNameLowercase = a.userName.toLowerCase();
 				const bUserNameLowercase = b.userName.toLowerCase();

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -264,7 +264,7 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec = await getServerSpec(session.serverName);
 		if (serverSpec) {
-			serverSpec.auth.resolve({ accessToken: session.accessToken })
+			serverSpec.auth.resolve({ accessToken: session.accessToken, username: session.userName })
 			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
 			if (response?.status == 401) {
 				await this._removeSession(session.id, true);

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -1,4 +1,4 @@
-import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
+import { Authorization, IServerSpecWithAuth, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 import {
 	authentication,
 	AuthenticationProvider,
@@ -17,8 +17,15 @@ import {
 import { getServerSpec } from "./api/getServerSpec";
 import { ServerManagerAuthenticationSession } from "./authenticationSession";
 import { globalState, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
+import { log } from "./logger";
 import { logout, makeRESTRequest } from "./makeRESTRequest";
-import { performOAuth2Login } from "./oauth2Flow";
+import { IOAuth2Config, performOAuth2Login, refreshOAuth2Token } from "./oauth2Flow";
+
+interface IOAuth2Secret {
+	refreshToken?: string;
+	/** Epoch milliseconds at which the access token should be treated as expired. */
+	expiresAt?: number;
+}
 
 export const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
 const AUTHENTICATION_PROVIDER_LABEL = "InterSystems Server Credentials";
@@ -44,21 +51,33 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	public static credentialKey(sessionId: string): string {
 		return `${ServerManagerAuthenticationProvider.secretKeyPrefix}${sessionId}`;
 	}
+	// Refresh tokens are kept privately under a separate key and never exposed as an accessToken.
+	public static oauth2SecretKey(sessionId: string): string {
+		return `${ServerManagerAuthenticationProvider.secretKeyPrefix}${sessionId}:oauth2`;
+	}
+	public static oauth2Config(spec: IServerSpecWithAuth): IOAuth2Config {
+		const oauth2 = (spec.auth as OAuth2Authorization).oauth2;
+		return {
+			authority: oauth2.authority,
+			clientId: oauth2.clientId,
+			audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`,
+		};
+	}
 
 	private _initializedDisposable: Disposable | undefined;
 
-	private readonly _secretStorage;
-
 	private _sessions: ServerManagerAuthenticationSession[] = [];
 	private _checkedSessions: ServerManagerAuthenticationSession[] = [];
+
+	// Guards against concurrent refreshes of the same session, which would
+	// invalidate each other when the provider rotates refresh tokens.
+	private _refreshInFlight = new Map<string, Promise<string | undefined>>();
 
 	private _serverManagerExtension = extensions.getExtension("intersystems-community.servermanager");
 
 	private _onDidChangeSessions = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
 
-	constructor(private readonly secretStorage: SecretStorage) {
-		this._secretStorage = secretStorage;
-	}
+	constructor(private readonly secretStorage: SecretStorage) {}
 
 	public dispose(): void {
 
@@ -99,7 +118,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 	// - The end user initiates the "silent" auth flow via the Accounts menu
 	public async createSession(scopes: string[]): Promise<AuthenticationSession> {
 		await this._ensureInitialized();
-
 		const serverName = scopes[0] || await this.promptServerName();
 		const spec = await getServerSpec(serverName);
 		const userName = scopes[1] || spec?.auth.username || await this.promptUserName(serverName);
@@ -117,13 +135,12 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			let accessToken = await this.secretStorage.get(credentialKey);
 			if (accessToken === undefined) {
 				if (spec?.auth instanceof OAuth2Authorization) {
-					accessToken = await performOAuth2Login({
-						authority: spec?.auth.oauth2.authority,
-						clientId: spec?.auth.oauth2.clientId,
-						audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`,
-					});
-					if (this.secretStorage && accessToken) {
-						await this.secretStorage?.store(credentialKey, accessToken);
+					const tokenSet = await performOAuth2Login(sessionId, ServerManagerAuthenticationProvider.oauth2Config(spec));
+					accessToken = tokenSet?.accessToken;
+					if (accessToken) {
+						await this.secretStorage.store(credentialKey, accessToken);
+						await this._storeOAuth2Secret(sessionId, tokenSet);
+						log(`OAuth2 [${sessionId}]: login complete, ${tokenSet?.refreshToken ? "refresh token stored" : "no refresh token"}`);
 					}
 				} else {
 					// Password is "" if userName is ""
@@ -143,24 +160,33 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 
 	// This function is called when the end user signs out of the account.
 	public async removeSession(sessionId: string): Promise<void> {
-		this._removeSession(sessionId);
+		await this._removeSession(sessionId);
 	}
 
 	public async removeSessions(sessionIds: string[]): Promise<void> {
 		const storedPasswordCredKeys: string[] = [];
 		const removed: AuthenticationSession[] = [];
 		await Promise.allSettled(sessionIds.map(async (sessionId) => {
-			const index = this._sessions.findIndex((item) => item.id === sessionId);
-			const session = this._sessions[index];
+			const session = this._sessions.find((item) => item.id === sessionId);
 			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+			const isOAuth2 = await this._isOAuth2Session(sessionId, session);
 			if (await this.secretStorage.get(credentialKey) !== undefined) {
-				storedPasswordCredKeys.push(credentialKey);
+				if (isOAuth2) {
+					await this.secretStorage.delete(credentialKey);
+				} else {
+					storedPasswordCredKeys.push(credentialKey);
+				}
 			}
-			if (index > -1) {
-				this._sessions.splice(index, 1);
+			// Always clear the private refresh token on sign-out
+			await this.secretStorage.delete(ServerManagerAuthenticationProvider.oauth2SecretKey(sessionId));
+			if (session) {
+				removed.push(session);
 			}
-			removed.push(session);
 		}));
+		// Remove from _sessions in a single pass; splicing by index inside the concurrent
+		// loop above races, since each splice shifts the indexes the others captured.
+		const removedIds = new Set(sessionIds);
+		this._sessions = this._sessions.filter((s) => !removedIds.has(s.id));
 		if (storedPasswordCredKeys.length) {
 			const passwordOption = workspace.getConfiguration("intersystemsServerManager.credentialsProvider")
 				.get<string>("deletePasswordOnSignout", "ask");
@@ -308,11 +334,24 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		}
 		const serverSpec = await getServerSpec(session.serverName);
 		if (serverSpec) {
+			const isOAuth2 = serverSpec.auth instanceof OAuth2Authorization;
+			// Proactively renew an expired OAuth2 access token so we don't send a request we know will fail
+			if (isOAuth2 && await this._isAccessTokenExpired(session.id)) {
+				log(`OAuth2 [${session.id}]: access token expired, refreshing proactively`);
+				session = await this._tryRefresh(session, serverSpec) ?? session;
+			}
 			serverSpec.auth.resolve({ accessToken: session.accessToken, username: session.userName });
-			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => { /* Swallow errors */ });
+			const response = await makeRESTRequest("HEAD", serverSpec).catch(() => undefined);
 			if (response?.status == 401) {
-				await this._removeSession(session.id, true);
-				return false;
+				// Before giving up and forcing an interactive login, try to renew via refresh token
+				if (isOAuth2) { log(`OAuth2 [${session.id}]: got 401, attempting refresh`); }
+				const refreshed = isOAuth2 ? await this._tryRefresh(session, serverSpec) : undefined;
+				if (!refreshed) {
+					if (isOAuth2) { log(`OAuth2 [${session.id}]: refresh unavailable, signing out (re-login required)`); }
+					await this._removeSession(session.id, true);
+					return false;
+				}
+				session = refreshed;
 			}
 			// Immediately log out the session created by credentials test
 			await logout(session.serverName);
@@ -321,14 +360,95 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		return true;
 	}
 
+	/**
+	 * Attempt to renew an OAuth2 access token using the privately-stored refresh token.
+	 * On success the new access token is written to secret storage (which propagates to all
+	 * windows) and the in-memory session is replaced. Concurrent callers share one refresh.
+	 *
+	 * @returns The refreshed session, or undefined if there is no refresh token or it is no longer valid.
+	 */
+	private async _tryRefresh(
+		session: ServerManagerAuthenticationSession,
+		serverSpec: IServerSpecWithAuth,
+	): Promise<ServerManagerAuthenticationSession | undefined> {
+		const existing = this._refreshInFlight.get(session.id);
+		const promise = existing ?? this._doRefresh(session.id, serverSpec);
+		if (!existing) {
+			this._refreshInFlight.set(session.id, promise);
+		}
+		let accessToken: string | undefined;
+		try {
+			accessToken = await promise;
+		} finally {
+			if (!existing) {
+				this._refreshInFlight.delete(session.id);
+			}
+		}
+		if (!accessToken) { return undefined; }
+		const index = this._sessions.findIndex((s) => s.id === session.id);
+		const refreshed = new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken);
+		if (index > -1) {
+			this._sessions[index] = refreshed;
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [refreshed] });
+		}
+		return refreshed;
+	}
+
+	private async _doRefresh(sessionId: string, serverSpec: IServerSpecWithAuth): Promise<string | undefined> {
+		const secret = await this._getOAuth2Secret(sessionId);
+		if (!secret?.refreshToken) {
+			log(`OAuth2 [${sessionId}]: no refresh token stored`);
+			return undefined;
+		}
+		const tokenSet = await refreshOAuth2Token(sessionId, ServerManagerAuthenticationProvider.oauth2Config(serverSpec), secret.refreshToken);
+		if (!tokenSet) { return undefined; }
+		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+		await this.secretStorage.store(credentialKey, tokenSet.accessToken);
+		await this._storeOAuth2Secret(sessionId, tokenSet);
+		log(`OAuth2 [${sessionId}]: access token refreshed successfully`);
+		return tokenSet.accessToken;
+	}
+
+	private async _isAccessTokenExpired(sessionId: string): Promise<boolean> {
+		const secret = await this._getOAuth2Secret(sessionId);
+		return secret?.expiresAt !== undefined && Date.now() >= secret.expiresAt;
+	}
+
+	// OAuth2 access tokens are not passwords: never prompt to "keep", always clear them.
+	private async _isOAuth2Session(sessionId: string, session?: ServerManagerAuthenticationSession): Promise<boolean> {
+		if (await this.secretStorage.get(ServerManagerAuthenticationProvider.oauth2SecretKey(sessionId)) !== undefined) { return true; }
+		return session !== undefined && (await getServerSpec(session.serverName))?.auth instanceof OAuth2Authorization;
+	}
+
+	private async _getOAuth2Secret(sessionId: string): Promise<IOAuth2Secret | undefined> {
+		const raw = await this.secretStorage.get(ServerManagerAuthenticationProvider.oauth2SecretKey(sessionId));
+		if (!raw) { return undefined; }
+		try {
+			return JSON.parse(raw) as IOAuth2Secret;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private async _storeOAuth2Secret(sessionId: string, tokenSet?: IOAuth2Secret): Promise<void> {
+		const key = ServerManagerAuthenticationProvider.oauth2SecretKey(sessionId);
+		if (!tokenSet?.refreshToken) {
+			// No refresh token issued (or none anymore): don't leave a stale one behind
+			await this.secretStorage.delete(key);
+			return;
+		}
+		await this.secretStorage.store(key, JSON.stringify({ refreshToken: tokenSet.refreshToken, expiresAt: tokenSet.expiresAt }));
+	}
+
 	private async _removeSession(sessionId: string, alwaysDeletePassword = false): Promise<void> {
 		const index = this._sessions.findIndex((item) => item.id === sessionId);
 		const session = this._sessions[index];
 
 		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+		const isOAuth2 = await this._isOAuth2Session(sessionId, session);
 		let deletePassword = false;
 		const hasStoredPassword = await this.secretStorage.get(credentialKey) !== undefined;
-		if (alwaysDeletePassword) {
+		if (alwaysDeletePassword || isOAuth2) {
 			deletePassword = hasStoredPassword;
 		} else {
 			if (hasStoredPassword) {
@@ -350,6 +470,8 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			// Delete from secret storage
 			await this.secretStorage.delete(credentialKey);
 		}
+		// Always clear the private refresh token when the session goes away
+		await this.secretStorage.delete(ServerManagerAuthenticationProvider.oauth2SecretKey(sessionId));
 		if (index > -1) {
 			// Remove session here so we don't store it
 			this._sessions.splice(index, 1);
@@ -409,25 +531,14 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		this._sessions = (await Promise.all(
 			strippedSessions.map(async (session) => {
 				const credentialKey = ServerManagerAuthenticationProvider.credentialKey(session.id);
-				const accessToken = await this._secretStorage.get(credentialKey);
+				const accessToken = await this.secretStorage.get(credentialKey);
 				if (accessToken === undefined) { return []; }
 				return [new ServerManagerAuthenticationSession(session.serverName, session.userName, accessToken)];
 			})))
 			.flat(1)
-			.sort((a, b) => {
-				const aUserNameLowercase = a.userName.toLowerCase();
-				const bUserNameLowercase = b.userName.toLowerCase();
-				if (aUserNameLowercase < bUserNameLowercase) {
-					return -1;
-				}
-				if (aUserNameLowercase > bUserNameLowercase) {
-					return 1;
-				}
-				if (a.serverName < b.serverName) {
-					return -1;
-				}
-				return 1;
-			});
+			.sort((a, b) =>
+				a.userName.toLowerCase().localeCompare(b.userName.toLowerCase())
+				|| a.serverName.localeCompare(b.serverName));
 	}
 
 	private async _storeStrippedSessions() {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -128,26 +128,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 		};
 	}
 
-	private async _finalizeSession(serverName: string, auth: ResolvedAuthorization): Promise<AuthenticationSession> {
-		// We have all we need to create the session object
-		const session = new ServerManagerAuthenticationSession(serverName, auth.username, auth.accessToken);
-		// Update this._sessions and raise the event to notify
-		const added: AuthenticationSession[] = [];
-		const changed: AuthenticationSession[] = [];
-		const index = this._sessions.findIndex((item) => item.id === session.id);
-		if (index !== -1) {
-			this._sessions[index] = session;
-			changed.push(session);
-		} else {
-			// No point re-sorting here because onDidChangeSessions always appends added items to the provider's entries in the Accounts menu
-			this._sessions.push(session);
-			added.push(session);
-		}
-		await this._storeStrippedSessions();
-		this._onDidChangeSessions.fire({ added, removed: [], changed });
-		return session;
-	}
-
 	private async promptServerName(): Promise<string> {
 		if (!this._serverManagerExtension) {
 			throw new Error(`InterSystems Server Manager extension is not available to provide server selection for ${AUTHENTICATION_PROVIDER_LABEL}.`);
@@ -249,6 +229,26 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			throw new Error(`${AUTHENTICATION_PROVIDER_LABEL}: Password is required.`);
 		}
 		return password;
+	}
+
+	private async _finalizeSession(serverName: string, auth: ResolvedAuthorization): Promise<AuthenticationSession> {
+		// We have all we need to create the session object
+		const session = new ServerManagerAuthenticationSession(serverName, auth.username, auth.accessToken);
+		// Update this._sessions and raise the event to notify
+		const added: AuthenticationSession[] = [];
+		const changed: AuthenticationSession[] = [];
+		const index = this._sessions.findIndex((item) => item.id === session.id);
+		if (index !== -1) {
+			this._sessions[index] = session;
+			changed.push(session);
+		} else {
+			// No point re-sorting here because onDidChangeSessions always appends added items to the provider's entries in the Accounts menu
+			this._sessions.push(session);
+			added.push(session);
+		}
+		await this._storeStrippedSessions();
+		this._onDidChangeSessions.fire({ added, removed: [], changed });
+		return session;
 	}
 
 	private async _isStillValid(session: ServerManagerAuthenticationSession): Promise<boolean> {

--- a/src/authenticationProvider.ts
+++ b/src/authenticationProvider.ts
@@ -110,16 +110,29 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 			return existingSession;
 		}
 		let auth: Authorization;
-		if (spec?.auth instanceof OAuth2Authorization) {
-			const accessToken = await performOAuth2Login({
-				authority: spec.auth.oauth2.authority,
-				clientId: spec.auth.oauth2.clientId,
-				audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
-			});
-			auth = new OAuth2Authorization(spec.auth.oauth2, accessToken);
+		if (spec?.auth.resolved()) {
+			auth = spec.auth;
 		} else {
-			const password = userName && await this.seekPassword(sessionId, userName, serverName);
-			auth = new PasswordAuthorization(userName, password);
+			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
+			let accessToken = await this.secretStorage.get(credentialKey);
+			if (accessToken === undefined) {
+				if (spec?.auth instanceof OAuth2Authorization) {
+					accessToken = await performOAuth2Login({
+						authority: spec?.auth.oauth2.authority,
+						clientId: spec?.auth.oauth2.clientId,
+						audience: `${spec.webServer.scheme || "http"}://${spec.webServer.host}:${spec.webServer.port}/`
+					});
+					if (this.secretStorage && accessToken) {
+						await this.secretStorage?.store(credentialKey, accessToken);
+					}
+				} else {
+					// Password is "" if userName is ""
+					accessToken = userName && await this.promptPassword(userName, serverName, credentialKey);
+				}
+
+			}
+			auth = spec?.auth.clone() ?? new PasswordAuthorization();
+			auth.resolve({ username: userName, accessToken })
 		}
 		if (auth.resolved()) {
 			return this._finalizeSession(serverName, auth);
@@ -169,12 +182,6 @@ export class ServerManagerAuthenticationProvider implements AuthenticationProvid
 				return existingSession;
 			}
 		}
-	}
-
-	private async seekPassword(sessionId: string, userName: string, serverName: string): Promise<string> {
-		// Seek password in secret storage
-		const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
-		return await this.secretStorage.get(credentialKey) ?? await this.promptPassword(userName, serverName, credentialKey);
 	}
 
 	private async promptPassword(userName: string, serverName: string, credentialKey: string): Promise<string> {

--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -1,5 +1,6 @@
 import { AuthenticationSession, AuthenticationSessionAccountInformation } from "vscode";
 import { ServerManagerAuthenticationProvider } from "./authenticationProvider";
+import { ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export class ServerManagerAuthenticationSession implements AuthenticationSession {
 	public readonly id: string;
@@ -7,11 +8,17 @@ export class ServerManagerAuthenticationSession implements AuthenticationSession
 	public readonly scopes: string[];
 	constructor(
 		public readonly serverName: string,
-		public readonly userName: string,
-		public readonly accessToken: string,
+		private readonly authorization: ResolvedAuthorization,
 	) {
+		const userName = authorization.username;
 		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
 		this.account = { id: `${serverName}/${userName}`, label: `${userName} on ${serverName}` };
 		this.scopes = [serverName, userName];
+	}
+	public get accessToken() {
+		return this.authorization.accessToken;
+	}
+	public get userName() {
+		return this.authorization.username;
 	}
 }

--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -1,6 +1,6 @@
 import { AuthenticationSession, AuthenticationSessionAccountInformation } from "vscode";
 import { ServerManagerAuthenticationProvider } from "./authenticationProvider";
-import { ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
+import { ResolvedAuthorization } from "./commonActivate";
 
 export class ServerManagerAuthenticationSession implements AuthenticationSession {
 	public readonly id: string;

--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -8,17 +8,16 @@ export class ServerManagerAuthenticationSession implements AuthenticationSession
 	public readonly scopes: string[];
 	constructor(
 		public readonly serverName: string,
-		public readonly authorization: ResolvedAuthorization,
+		public readonly auth: ResolvedAuthorization,
 	) {
-		const userName = authorization.username;
-		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-		this.account = { id: `${serverName}/${userName}`, label: `${userName} on ${serverName}` };
-		this.scopes = [serverName, userName];
+		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, auth.username);
+		this.account = { id: `${serverName}/${auth.username}`, label: `${auth.username} on ${serverName}` };
+		this.scopes = [serverName, (auth.username)];
 	}
 	public get accessToken() {
-		return this.authorization.accessToken;
+		return this.auth.accessToken;
 	}
 	public get userName() {
-		return this.authorization.username;
+		return this.auth.username;
 	}
 }

--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -1,6 +1,5 @@
 import { AuthenticationSession, AuthenticationSessionAccountInformation } from "vscode";
 import { ServerManagerAuthenticationProvider } from "./authenticationProvider";
-import { ResolvedAuthorization } from "./commonActivate";
 
 export class ServerManagerAuthenticationSession implements AuthenticationSession {
 	public readonly id: string;
@@ -8,16 +7,11 @@ export class ServerManagerAuthenticationSession implements AuthenticationSession
 	public readonly scopes: string[];
 	constructor(
 		public readonly serverName: string,
-		public readonly auth: ResolvedAuthorization,
+		public readonly userName: string,
+		public readonly accessToken: string,
 	) {
-		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, auth.username);
-		this.account = { id: `${serverName}/${auth.username}`, label: `${auth.username} on ${serverName}` };
-		this.scopes = [serverName, (auth.username)];
-	}
-	public get accessToken() {
-		return this.auth.accessToken;
-	}
-	public get userName() {
-		return this.auth.username;
+		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
+		this.account = { id: `${serverName}/${userName}`, label: `${userName} on ${serverName}` };
+		this.scopes = [serverName, userName];
 	}
 }

--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -8,7 +8,7 @@ export class ServerManagerAuthenticationSession implements AuthenticationSession
 	public readonly scopes: string[];
 	constructor(
 		public readonly serverName: string,
-		private readonly authorization: ResolvedAuthorization,
+		public readonly authorization: ResolvedAuthorization,
 	) {
 		const userName = authorization.username;
 		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, userName);

--- a/src/authenticationSession.ts
+++ b/src/authenticationSession.ts
@@ -3,16 +3,14 @@ import { ServerManagerAuthenticationProvider } from "./authenticationProvider";
 
 export class ServerManagerAuthenticationSession implements AuthenticationSession {
 	public readonly id: string;
-	public readonly accessToken: string;
 	public readonly account: AuthenticationSessionAccountInformation;
 	public readonly scopes: string[];
 	constructor(
 		public readonly serverName: string,
 		public readonly userName: string,
-		password: string,
+		public readonly accessToken: string,
 	) {
 		this.id = ServerManagerAuthenticationProvider.sessionId(serverName, userName);
-		this.accessToken = password;
 		this.account = { id: `${serverName}/${userName}`, label: `${userName} on ${serverName}` };
 		this.scopes = [serverName, userName];
 	}

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -109,8 +109,6 @@ export class OAuth2Authorization extends Authorization {
 	public get httpAuthorizationHeader(): string | undefined {
 		if (this.resolved()) {
 			return `Bearer ${this._bearer}`;
-		} else {
-			return undefined;
 		}
 	}
 
@@ -144,12 +142,14 @@ export class OAuth2Authorization extends Authorization {
 	}
 
 
-	public get credentials(): { auth?: { username: string; password: string }; headers: Record<string, string> } {
-		return {
-			headers: {
-				Authorization: this.httpAuthorizationHeader,
-			}
-		};
+	public get credentials(): { auth?: { username: string; password: string }; headers: Record<string, string> } | undefined {
+		if (this.resolved()) {
+			return {
+				headers: {
+					Authorization: this.httpAuthorizationHeader,
+				}
+			};
+		}
 	}
 
 	public clone(): OAuth2Authorization {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -25,6 +25,8 @@ abstract class Authorization {
 	public abstract resolved(): this is ResolvedAuthorization;
 
 	public abstract resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
+
+	public abstract get username(): string;
 }
 
 export class PasswordAuthorization extends Authorization {
@@ -83,8 +85,8 @@ export class OAuth2Authorization extends Authorization {
 		return true;
 	}
 
-	public get username(): undefined {
-		return undefined;
+	public get username(): string {
+		return "OAuth2User";
 	}
 	public get password(): undefined {
 		return undefined;

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -111,7 +111,7 @@ export class OAuth2Authorization extends Authorization {
 	}
 
 	override resolved(): this is ResolvedAuthorization {
-		return this._bearer !== undefined
+		return this._bearer ? true : false;
 	}
 
 	override resolve({ accessToken, username }): this is ResolvedAuthorization {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -490,6 +490,10 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			return _onDidChangePassword.event;
 		},
 
+		makeAuthorization(username, password) {
+			return new PasswordAuthorization(username ?? "", password)
+		},
+
 	};
 
 	// 'export' the API

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -24,24 +24,36 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 abstract class Authorization {
 	public abstract resolved(): this is ResolvedAuthorization;
 
-	public abstract resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
+	public abstract resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization;
 
 	public abstract get username(): string;
+	public abstract get password(): undefined | string;
+	public abstract get accessToken(): undefined | string;
 
 	public abstract clone(): Authorization;
 }
 
 export class PasswordAuthorization extends Authorization {
-	constructor(private _username: string, private _password?: string) {
+	constructor(private _username?: string, private _password?: string) {
 		super()
 	}
 
+	public static new(username: string, password: string): ResolvedAuthorization {
+		const self: Authorization = new PasswordAuthorization();
+		self.resolve(username, password);
+		return self;
+	}
+
 	public get username(): string {
-		return this._username;
+		return this._username || "";
 	}
 
 	public get password(): string | undefined {
 		return this._password;
+	}
+
+	public get accessToken(): string | undefined {
+		return this._password
 	}
 
 	public get httpAuthorizationHeader(): string {
@@ -52,17 +64,17 @@ export class PasswordAuthorization extends Authorization {
 		return this.username !== "" && this._password !== undefined
 	}
 
-	override resolve(accessToken: string, username?: string): this is ResolvedAuthorization {
-		this._username = username ?? this._username;
+	override resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization {
+		this._username = username;
 		this._password = accessToken;
-		return true;
+		return;
 	}
 
 	public get credentials(): { auth: { username: string; password: string }; headers?: Record<string, string> } {
 		return {
 			auth: {
-				username: this._username,
-				password: this._password!,
+				username: this.username,
+				password: this.password!,
 			},
 			headers: {}
 		};
@@ -74,6 +86,7 @@ export class PasswordAuthorization extends Authorization {
 }
 
 export class OAuth2Authorization extends Authorization {
+	private _username: string = "OAuth2User";
 	constructor(public readonly oauth2: OAuth2Config, private _bearer?: string) {
 		super()
 	}
@@ -86,17 +99,24 @@ export class OAuth2Authorization extends Authorization {
 		return this._bearer !== undefined
 	}
 
-	override resolve(accessToken: string): this is ResolvedAuthorization {
+	override resolve(accessToken: string, _username: string): asserts this is ResolvedAuthorization {
 		this._bearer = accessToken;
-		return true;
+		this._username = _username;
+		return;
 	}
 
 	public get username(): string {
-		return "OAuth2User";
+		return this._username;
 	}
+
 	public get password(): undefined {
 		return undefined;
 	}
+
+	public get accessToken(): string | undefined {
+		return this._bearer
+	}
+
 
 	public get credentials(): { auth?: { username: string; password: string }; headers: Record<string, string> } {
 		return {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -509,8 +509,8 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			return spec;
 		},
 
-		getAccount(serverSpec: { name: string, username?: string }): vscode.AuthenticationSessionAccountInformation | undefined {
-			return getAccountFromParts(serverSpec.name, serverSpec["username"]);
+		getAccount(serverSpec: Pick<IServerSpec, "name" | "username">): vscode.AuthenticationSessionAccountInformation | undefined {
+			return getAccountFromParts(serverSpec.name, serverSpec.username);
 		},
 
 		onDidChangePassword(

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -407,7 +407,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			}
 		},
 
-		getAccount(serverSpec: IServerSpec): vscode.AuthenticationSessionAccountInformation | undefined {
+		getAccount(serverSpec: { name: string, username?: string }): vscode.AuthenticationSessionAccountInformation | undefined {
 			return getAccountFromParts(serverSpec.name, serverSpec["username"]);
 		},
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,14 +1,15 @@
 import * as vscode from "vscode";
-import { Authorization, IServerName, IServerSpec, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
+import { IServerName, IServerSpec, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
-import { getServerSetting } from "./api/getServerSpec";
+import { getServerSpec } from "./api/getServerSpec";
 import { getServerSummary } from "./api/getServerSummary";
 import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
 import { logout, serverSessions } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
+import { OAuth2Config } from "./serverSetting";
 
 export const extensionId = "intersystems-community.servermanager";
 export const OBJECTSCRIPT_EXTENSIONID = "intersystems-community.vscode-objectscript";
@@ -18,6 +19,84 @@ export let globalState: vscode.Memento;
 export function getAccountFromParts(serverName: string, userName?: string): vscode.AuthenticationSessionAccountInformation | undefined {
 	const accountId = userName ? `${serverName}/${userName}` : undefined;
 	return accountId ? { id: accountId, label: `${userName} on ${serverName}` } : undefined;
+}
+
+abstract class Authorization {
+	public abstract resolved(): this is ResolvedAuthorization;
+
+	public abstract resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
+}
+
+export class PasswordAuthorization extends Authorization {
+	constructor(private _username: string, private _password?: string) {
+		super()
+	}
+
+	public get username(): string {
+		return this._username;
+	}
+
+	public get password(): string | undefined {
+		return this._password;
+	}
+
+	public get httpAuthorizationHeader(): string {
+		return `Basic ${Buffer.from(`${this._username}:${this._password}`).toString("base64")}`;
+	}
+
+	override resolved(): this is ResolvedAuthorization {
+		return this._password !== undefined
+	}
+
+	override resolve(accessToken: string, username?: string): this is ResolvedAuthorization {
+		this._username = username ?? this._username;
+		this._password = accessToken;
+		return true;
+	}
+
+	public get credentials(): { auth: { username: string; password: string }; headers?: Record<string, string> } {
+		return {
+			auth: {
+				username: this._username,
+				password: this._password!,
+			},
+			headers: {}
+		};
+	}
+}
+
+export class OAuth2Authorization extends Authorization {
+	constructor(public oauth2: OAuth2Config, private _bearer?: string) {
+		super()
+	}
+
+	public get httpAuthorizationHeader(): string {
+		return `Bearer ${this._bearer}`;
+	}
+
+	override resolved(): this is ResolvedAuthorization {
+		return this._bearer !== undefined
+	}
+
+	override resolve(accessToken: string): this is ResolvedAuthorization {
+		this._bearer = accessToken;
+		return true;
+	}
+
+	public get username(): undefined {
+		return undefined;
+	}
+	public get password(): undefined {
+		return undefined;
+	}
+
+	public get credentials(): { auth?: { username: string; password: string }; headers: Record<string, string> } {
+		return {
+			headers: {
+				Authorization: this.httpAuthorizationHeader,
+			}
+		};
+	}
 }
 
 /**
@@ -37,7 +116,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			if (pathParts && pathParts.length === 4) {
 				const serverName = pathParts[1];
 				const namespace = pathParts[3];
-				const serverSetting = await getServerSetting(serverName);
+				const serverSetting = await getServerSpec(serverName);
 				if (serverSetting) {
 					const isfsExtension = vscode.extensions.getExtension(OBJECTSCRIPT_EXTENSIONID);
 					if (isfsExtension) {
@@ -390,8 +469,8 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			flushCredentialCache: boolean = false,
 			options?: { hideFromRecents?: boolean, /* Obsolete */ noCredentials?: boolean },
 		): Promise<IServerSpec | undefined> {
-			const setting = await getServerSetting(name, scope);
-			if (!setting) {
+			const spec = await getServerSpec(name, scope);
+			if (spec === undefined) {
 				return undefined;
 			}
 
@@ -399,12 +478,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				await view.addToRecents(name);
 			}
 
-			if ('oauth2' in setting) {
-				const { oauth2, ...rest } = setting;
-				return { ...rest, bearer_token: undefined };
-			} else {
-				return setting;
-			}
+			return spec;
 		},
 
 		getAccount(serverSpec: { name: string, username?: string }): vscode.AuthenticationSessionAccountInformation | undefined {
@@ -415,15 +489,6 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		): vscode.Event<string> {
 			return _onDidChangePassword.event;
 		},
-
-		getAuthorization(authorization: Required<Authorization>): string {
-			if ('bearer_token' in authorization) {
-				return `Bearer ${authorization.bearer_token}`;
-			} else {
-				return `Basic ${Buffer.from(`${authorization.username}:${authorization.password}`).toString("base64")} `;
-			}
-		}
-
 
 	};
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { Authorization, IServerName, IServerSpec, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
+import { IServerName, IServerSpec, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -21,6 +21,22 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 	return accountId ? { id: accountId, label: `${userName} on ${serverName}` } : undefined;
 }
 
+export abstract class Authorization {
+	public abstract resolved(): this is ResolvedAuthorization;
+	public abstract resolve(params: { accessToken: string; username: string }): asserts this is ResolvedAuthorization;
+	public abstract clear(): asserts this is Authorization;
+	public abstract get username(): string;
+	public abstract get password(): undefined | string;
+	public abstract get accessToken(): undefined | string;
+	public abstract clone(): Authorization;
+}
+
+export abstract class ResolvedAuthorization extends Authorization {
+	public abstract get accessToken(): string;
+	public abstract get httpAuthorizationHeader(): string;
+	public abstract get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
+}
+
 export class PasswordAuthorization extends Authorization {
 	constructor(private _username?: string, private _password?: string) {
 		super()
@@ -28,7 +44,7 @@ export class PasswordAuthorization extends Authorization {
 
 	public static new(username: string, password: string): ResolvedAuthorization {
 		const self: Authorization = new PasswordAuthorization();
-		self.resolve(username, password);
+		self.resolve({ accessToken: password, username });
 		return self;
 	}
 
@@ -52,7 +68,7 @@ export class PasswordAuthorization extends Authorization {
 		return this.username !== "" && this._password !== undefined
 	}
 
-	override resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization {
+	override resolve({ accessToken, username }): asserts this is ResolvedAuthorization {
 		this._username = username;
 		this._password = accessToken;
 		return;
@@ -91,9 +107,9 @@ export class OAuth2Authorization extends Authorization {
 		return this._bearer !== undefined
 	}
 
-	override resolve(accessToken: string, _username: string): asserts this is ResolvedAuthorization {
+	override resolve({ accessToken, username }): asserts this is ResolvedAuthorization {
 		this._bearer = accessToken;
-		this._username = _username;
+		this._username = username;
 		return;
 	}
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -106,8 +106,12 @@ export class OAuth2Authorization extends Authorization {
 		super()
 	}
 
-	public get httpAuthorizationHeader(): string {
-		return `Bearer ${this._bearer}`;
+	public get httpAuthorizationHeader(): string | undefined {
+		if (this.resolved()) {
+			return `Bearer ${this._bearer}`;
+		} else {
+			return undefined;
+		}
 	}
 
 	override resolved(): this is ResolvedAuthorization {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerName, IServerSpec, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
+import { Authorization, IServerName, IServerSpec, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -19,18 +19,6 @@ export let globalState: vscode.Memento;
 export function getAccountFromParts(serverName: string, userName?: string): vscode.AuthenticationSessionAccountInformation | undefined {
 	const accountId = userName ? `${serverName}/${userName}` : undefined;
 	return accountId ? { id: accountId, label: `${userName} on ${serverName}` } : undefined;
-}
-
-abstract class Authorization {
-	public abstract resolved(): this is ResolvedAuthorization;
-
-	public abstract resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization;
-
-	public abstract get username(): string;
-	public abstract get password(): undefined | string;
-	public abstract get accessToken(): undefined | string;
-
-	public abstract clone(): Authorization;
 }
 
 export class PasswordAuthorization extends Authorization {
@@ -70,6 +58,10 @@ export class PasswordAuthorization extends Authorization {
 		return;
 	}
 
+	public clear(): asserts this is Authorization {
+		this._password = undefined;
+	}
+
 	public get credentials(): { auth: { username: string; password: string }; headers?: Record<string, string> } {
 		return {
 			auth: {
@@ -103,6 +95,10 @@ export class OAuth2Authorization extends Authorization {
 		this._bearer = accessToken;
 		this._username = _username;
 		return;
+	}
+
+	public clear(): asserts this is Authorization {
+		this._bearer = undefined;
 	}
 
 	public get username(): string {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -9,7 +9,7 @@ import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
 import { logout, serverSessions } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
-import { OAuth2Config } from "./serverSetting";
+import { AuthRelatedSetting, OAuth2Config } from "./serverSetting";
 
 export const extensionId = "intersystems-community.servermanager";
 export const OBJECTSCRIPT_EXTENSIONID = "intersystems-community.vscode-objectscript";
@@ -23,12 +23,13 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 
 export abstract class Authorization {
 	public abstract resolved(): this is ResolvedAuthorization;
-	public abstract resolve(params: { accessToken: string; username: string }): asserts this is ResolvedAuthorization;
+	public abstract resolve(params: { accessToken?: string; username?: string }): this is ResolvedAuthorization;
 	public abstract clear(): asserts this is Authorization;
 	public abstract get username(): string;
 	public abstract get password(): undefined | string;
 	public abstract get accessToken(): undefined | string;
 	public abstract clone(): Authorization;
+	public abstract get setting(): AuthRelatedSetting;
 }
 
 export abstract class ResolvedAuthorization extends Authorization {
@@ -40,12 +41,6 @@ export abstract class ResolvedAuthorization extends Authorization {
 export class PasswordAuthorization extends Authorization {
 	constructor(private _username?: string, private _password?: string) {
 		super()
-	}
-
-	public static new(username: string, password: string): ResolvedAuthorization {
-		const self: Authorization = new PasswordAuthorization();
-		self.resolve({ accessToken: password, username });
-		return self;
 	}
 
 	public get username(): string {
@@ -68,10 +63,10 @@ export class PasswordAuthorization extends Authorization {
 		return this.username !== "" && this._password !== undefined
 	}
 
-	override resolve({ accessToken, username }): asserts this is ResolvedAuthorization {
-		this._username = username;
-		this._password = accessToken;
-		return;
+	override resolve({ accessToken, username }): this is ResolvedAuthorization {
+		this._username = username ?? this._username;
+		this._password = accessToken ?? this._password;
+		return this.resolved();
 	}
 
 	public clear(): asserts this is Authorization {
@@ -91,10 +86,22 @@ export class PasswordAuthorization extends Authorization {
 	public clone(): PasswordAuthorization {
 		return new PasswordAuthorization(this._username, this._password)
 	}
+
+	public get setting(): AuthRelatedSetting {
+		return {
+			username: this._username,
+		}
+	}
 }
 
 export class OAuth2Authorization extends Authorization {
-	private _username: string = "OAuth2User";
+	public get setting(): AuthRelatedSetting {
+		return {
+			...this._username === undefined ? {} : { username: this._username },
+			oauth2: this.oauth2,
+		}
+	}
+	private _username?: string;
 	constructor(public readonly oauth2: OAuth2Config, private _bearer?: string) {
 		super()
 	}
@@ -107,10 +114,13 @@ export class OAuth2Authorization extends Authorization {
 		return this._bearer !== undefined
 	}
 
-	override resolve({ accessToken, username }): asserts this is ResolvedAuthorization {
-		this._bearer = accessToken;
-		this._username = username;
-		return;
+	override resolve({ accessToken, username }): this is ResolvedAuthorization {
+		// empty accessTokens are ignored.
+		if (accessToken) {
+			this._bearer = accessToken;
+		}
+		this._username = username ?? this._username;
+		return this.resolved();
 	}
 
 	public clear(): asserts this is Authorization {
@@ -118,7 +128,7 @@ export class OAuth2Authorization extends Authorization {
 	}
 
 	public get username(): string {
-		return this._username;
+		return this._username ?? "OAuth2User";
 	}
 
 	public get password(): undefined {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { Authorization, IServerName, IServerSpec, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -24,7 +24,7 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
  * Handle all activation requirements that are shared by `extension.ts` and `web-extension.ts`.
  * Returns our exported API.
  */
-export function commonActivate(context: vscode.ExtensionContext, view: ServerManagerView): any {
+export function commonActivate(context: vscode.ExtensionContext, view: ServerManagerView): ServerManagerAPI {
 	const _onDidChangePassword = new vscode.EventEmitter<string>();
 
 	// Other parts of this extension will use this to persist state
@@ -344,7 +344,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 	);
 
 	// Create our exported API
-	const api = {
+	const api: ServerManagerAPI = {
 		async pickServer(
 			scope?: vscode.ConfigurationScope,
 			options: vscode.QuickPickOptions = {},
@@ -405,6 +405,14 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		): vscode.Event<string> {
 			return _onDidChangePassword.event;
 		},
+
+		getAuthorization(authorization: Required<Authorization>): string {
+			const { authMethod, username, password } = authorization;
+			return authMethod == "oauth2"
+				? `Bearer ${password}`
+				: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+		}
+
 
 	};
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -27,6 +27,8 @@ abstract class Authorization {
 	public abstract resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
 
 	public abstract get username(): string;
+
+	public abstract clone(): Authorization;
 }
 
 export class PasswordAuthorization extends Authorization {
@@ -47,7 +49,7 @@ export class PasswordAuthorization extends Authorization {
 	}
 
 	override resolved(): this is ResolvedAuthorization {
-		return this._password !== undefined
+		return this.username !== "" && this._password !== undefined
 	}
 
 	override resolve(accessToken: string, username?: string): this is ResolvedAuthorization {
@@ -65,10 +67,14 @@ export class PasswordAuthorization extends Authorization {
 			headers: {}
 		};
 	}
+
+	public clone(): PasswordAuthorization {
+		return new PasswordAuthorization(this._username, this._password)
+	}
 }
 
 export class OAuth2Authorization extends Authorization {
-	constructor(public oauth2: OAuth2Config, private _bearer?: string) {
+	constructor(public readonly oauth2: OAuth2Config, private _bearer?: string) {
 		super()
 	}
 
@@ -98,6 +104,10 @@ export class OAuth2Authorization extends Authorization {
 				Authorization: this.httpAuthorizationHeader,
 			}
 		};
+	}
+
+	public clone(): OAuth2Authorization {
+		return new OAuth2Authorization(this.oauth2, this._bearer)
 	}
 }
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -3,7 +3,7 @@ import { Authorization, IServerName, IServerSpec, ServerManagerAPI } from "@inte
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
-import { getServerSpec } from "./api/getServerSpec";
+import { getServerSetting } from "./api/getServerSpec";
 import { getServerSummary } from "./api/getServerSummary";
 import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
@@ -37,8 +37,8 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			if (pathParts && pathParts.length === 4) {
 				const serverName = pathParts[1];
 				const namespace = pathParts[3];
-				const serverSpec = await getServerSpec(serverName);
-				if (serverSpec) {
+				const serverSetting = await getServerSetting(serverName);
+				if (serverSetting) {
 					const isfsExtension = vscode.extensions.getExtension(OBJECTSCRIPT_EXTENSIONID);
 					if (isfsExtension) {
 						if (!isfsExtension.isActive) {
@@ -390,15 +390,25 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			flushCredentialCache: boolean = false,
 			options?: { hideFromRecents?: boolean, /* Obsolete */ noCredentials?: boolean },
 		): Promise<IServerSpec | undefined> {
-			const spec = await getServerSpec(name, scope);
-			if (spec && !options?.hideFromRecents) {
+			const setting = await getServerSetting(name, scope);
+			if (!setting) {
+				return undefined;
+			}
+
+			if (!options?.hideFromRecents) {
 				await view.addToRecents(name);
 			}
-			return spec;
+
+			if ('oauth2' in setting) {
+				const { oauth2, ...rest } = setting;
+				return { ...rest, bearer_token: undefined };
+			} else {
+				return setting;
+			}
 		},
 
 		getAccount(serverSpec: IServerSpec): vscode.AuthenticationSessionAccountInformation | undefined {
-			return getAccountFromParts(serverSpec.name, serverSpec.username);
+			return getAccountFromParts(serverSpec.name, serverSpec["username"]);
 		},
 
 		onDidChangePassword(
@@ -407,10 +417,11 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		},
 
 		getAuthorization(authorization: Required<Authorization>): string {
-			const { authMethod, username, password } = authorization;
-			return authMethod == "oauth2"
-				? `Bearer ${password}`
-				: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+			if ('bearer_token' in authorization) {
+				return `Bearer ${authorization.bearer_token}`;
+			} else {
+				return `Basic ${Buffer.from(`${authorization.username}:${authorization.password}`).toString("base64")} `;
+			}
 		}
 
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -22,37 +22,41 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 }
 
 export class PasswordAuthorization implements Authorization {
-	constructor(private _username?: string, private _password?: string) {
+	#username?: string;
+	#password?: string;
+	constructor(username?: string, password?: string) {
+		this.#username = username;
+		this.#password = password;
 	}
 
 	public get username(): string {
-		return this._username || "";
+		return this.#username || "";
 	}
 
 	public get password(): string | undefined {
-		return this._password;
+		return this.#password;
 	}
 
 	public get accessToken(): string | undefined {
-		return this._password
+		return this.#password
 	}
 
 	public get httpAuthorizationHeader(): string {
-		return `Basic ${Buffer.from(`${this._username}:${this._password}`).toString("base64")}`;
+		return `Basic ${Buffer.from(`${this.#username}:${this.#password}`).toString("base64")}`;
 	}
 
 	public resolved(): this is ResolvedAuthorization {
-		return this.username !== "" && this._password !== undefined
+		return this.username !== "" && this.#password !== undefined
 	}
 
 	public resolve({ accessToken, username }): this is ResolvedAuthorization {
-		this._username = username ?? this._username;
-		this._password = accessToken ?? this._password;
+		this.#username = username ?? this.#username;
+		this.#password = accessToken ?? this.#password;
 		return this.resolved();
 	}
 
 	public clear(): asserts this is Authorization {
-		this._password = undefined;
+		this.#password = undefined;
 	}
 
 	public get credentials(): { auth: { username: string; password: string }; headers?: Record<string, string> } {
@@ -66,52 +70,55 @@ export class PasswordAuthorization implements Authorization {
 	}
 
 	public clone(): PasswordAuthorization {
-		return new PasswordAuthorization(this._username, this._password)
+		return new PasswordAuthorization(this.#username, this.#password)
 	}
 
 	public get setting(): AuthRelatedSetting {
 		return {
-			username: this._username,
+			username: this.#username,
 		}
 	}
 }
 
 export class OAuth2Authorization implements Authorization {
+	#username?: string;
+	#bearer?: string;
+
 	public get setting(): AuthRelatedSetting {
 		return {
-			...this._username === undefined ? {} : { username: this._username },
+			...this.#username === undefined ? {} : { username: this.#username },
 			oauth2: this.oauth2,
 		}
 	}
-	private _username?: string;
-	constructor(public readonly oauth2: OAuth2Config, private _bearer?: string) {
+	constructor(public readonly oauth2: OAuth2Config, bearer?: string) {
+		this.#bearer = bearer
 	}
 
 	public get httpAuthorizationHeader(): string | undefined {
 		if (this.resolved()) {
-			return `Bearer ${this._bearer}`;
+			return `Bearer ${this.#bearer}`;
 		}
 	}
 
 	public resolved(): this is ResolvedAuthorization {
-		return this._bearer ? true : false;
+		return this.#bearer ? true : false;
 	}
 
 	public resolve({ accessToken, username }): this is ResolvedAuthorization {
 		// empty accessTokens are ignored.
 		if (accessToken) {
-			this._bearer = accessToken;
+			this.#bearer = accessToken;
 		}
-		this._username = username ?? this._username;
+		this.#username = username ?? this.#username;
 		return this.resolved();
 	}
 
 	public clear(): asserts this is Authorization {
-		this._bearer = undefined;
+		this.#bearer = undefined;
 	}
 
 	public get username(): string {
-		return this._username ?? "OAuth2User";
+		return this.#username ?? "OAuth2User";
 	}
 
 	public get password(): undefined {
@@ -119,7 +126,7 @@ export class OAuth2Authorization implements Authorization {
 	}
 
 	public get accessToken(): string | undefined {
-		return this._bearer
+		return this.#bearer
 	}
 
 
@@ -134,7 +141,7 @@ export class OAuth2Authorization implements Authorization {
 	}
 
 	public clone(): OAuth2Authorization {
-		return new OAuth2Authorization(this.oauth2, this._bearer)
+		return new OAuth2Authorization(this.oauth2, this.#bearer)
 	}
 }
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerName, IServerSpec, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
+import { Authorization, IServerName, IServerSpec, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -21,26 +21,8 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 	return accountId ? { id: accountId, label: `${userName} on ${serverName}` } : undefined;
 }
 
-export abstract class Authorization {
-	public abstract resolved(): this is ResolvedAuthorization;
-	public abstract resolve(params: { accessToken?: string; username?: string }): this is ResolvedAuthorization;
-	public abstract clear(): asserts this is Authorization;
-	public abstract get username(): string;
-	public abstract get password(): undefined | string;
-	public abstract get accessToken(): undefined | string;
-	public abstract clone(): Authorization;
-	public abstract get setting(): AuthRelatedSetting;
-}
-
-export abstract class ResolvedAuthorization extends Authorization {
-	public abstract get accessToken(): string;
-	public abstract get httpAuthorizationHeader(): string;
-	public abstract get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
-}
-
-export class PasswordAuthorization extends Authorization {
+export class PasswordAuthorization implements Authorization {
 	constructor(private _username?: string, private _password?: string) {
-		super()
 	}
 
 	public get username(): string {
@@ -59,11 +41,11 @@ export class PasswordAuthorization extends Authorization {
 		return `Basic ${Buffer.from(`${this._username}:${this._password}`).toString("base64")}`;
 	}
 
-	override resolved(): this is ResolvedAuthorization {
+	public resolved(): this is ResolvedAuthorization {
 		return this.username !== "" && this._password !== undefined
 	}
 
-	override resolve({ accessToken, username }): this is ResolvedAuthorization {
+	public resolve({ accessToken, username }): this is ResolvedAuthorization {
 		this._username = username ?? this._username;
 		this._password = accessToken ?? this._password;
 		return this.resolved();
@@ -94,7 +76,7 @@ export class PasswordAuthorization extends Authorization {
 	}
 }
 
-export class OAuth2Authorization extends Authorization {
+export class OAuth2Authorization implements Authorization {
 	public get setting(): AuthRelatedSetting {
 		return {
 			...this._username === undefined ? {} : { username: this._username },
@@ -103,7 +85,6 @@ export class OAuth2Authorization extends Authorization {
 	}
 	private _username?: string;
 	constructor(public readonly oauth2: OAuth2Config, private _bearer?: string) {
-		super()
 	}
 
 	public get httpAuthorizationHeader(): string | undefined {
@@ -112,11 +93,11 @@ export class OAuth2Authorization extends Authorization {
 		}
 	}
 
-	override resolved(): this is ResolvedAuthorization {
+	public resolved(): this is ResolvedAuthorization {
 		return this._bearer ? true : false;
 	}
 
-	override resolve({ accessToken, username }): this is ResolvedAuthorization {
+	public resolve({ accessToken, username }): this is ResolvedAuthorization {
 		// empty accessTokens are ignored.
 		if (accessToken) {
 			this._bearer = accessToken;
@@ -546,10 +527,6 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		onDidChangePassword(
 		): vscode.Event<string> {
 			return _onDidChangePassword.event;
-		},
-
-		makeAuthorization(username, password) {
-			return new PasswordAuthorization(username ?? "", password)
 		},
 
 	};

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -9,7 +9,7 @@ import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
 import { logout, serverSessions } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
-import { AuthRelatedSetting, OAuth2Config } from "./serverSetting";
+import { OAuth2Config } from "./serverSetting";
 
 export const extensionId = "intersystems-community.servermanager";
 export const OBJECTSCRIPT_EXTENSIONID = "intersystems-community.vscode-objectscript";
@@ -72,24 +72,11 @@ export class PasswordAuthorization implements Authorization {
 	public clone(): PasswordAuthorization {
 		return new PasswordAuthorization(this.#username, this.#password)
 	}
-
-	public get setting(): AuthRelatedSetting {
-		return {
-			username: this.#username,
-		}
-	}
 }
 
 export class OAuth2Authorization implements Authorization {
 	#username?: string;
 	#bearer?: string;
-
-	public get setting(): AuthRelatedSetting {
-		return {
-			...this.#username === undefined ? {} : { username: this.#username },
-			oauth2: this.oauth2,
-		}
-	}
 	constructor(public readonly oauth2: OAuth2Config, bearer?: string) {
 		this.#bearer = bearer
 	}

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
 import { Authorization, IServerName, IServerSpec, IServerSpecWithAuth, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
+import * as vscode from "vscode";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -8,8 +8,8 @@ import { getServerSummary } from "./api/getServerSummary";
 import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
 import { logout, serverSessions } from "./makeRESTRequest";
-import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
 import { OAuth2Config } from "./serverSetting";
+import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
 
 export const extensionId = "intersystems-community.servermanager";
 export const OBJECTSCRIPT_EXTENSIONID = "intersystems-community.vscode-objectscript";
@@ -22,8 +22,8 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 }
 
 export class PasswordAuthorization implements Authorization {
-	#username?: string;
-	#password?: string;
+	public #username?: string;
+	public #password?: string;
 	constructor(username?: string, password?: string) {
 		this.#username = username;
 		this.#password = password;
@@ -38,7 +38,7 @@ export class PasswordAuthorization implements Authorization {
 	}
 
 	public get accessToken(): string | undefined {
-		return this.#password
+		return this.#password;
 	}
 
 	public get httpAuthorizationHeader(): string {
@@ -46,7 +46,7 @@ export class PasswordAuthorization implements Authorization {
 	}
 
 	public resolved(): this is ResolvedAuthorization {
-		return this.username !== "" && this.#password !== undefined
+		return this.username !== "" && this.#password !== undefined;
 	}
 
 	public resolve({ accessToken, username }): this is ResolvedAuthorization {
@@ -65,20 +65,20 @@ export class PasswordAuthorization implements Authorization {
 				username: this.username,
 				password: this.password!,
 			},
-			headers: {}
+			headers: {},
 		};
 	}
 
 	public clone(): PasswordAuthorization {
-		return new PasswordAuthorization(this.#username, this.#password)
+		return new PasswordAuthorization(this.#username, this.#password);
 	}
 }
 
 export class OAuth2Authorization implements Authorization {
-	#username?: string;
-	#bearer?: string;
+	public #username?: string;
+	public #bearer?: string;
 	constructor(public readonly oauth2: OAuth2Config, bearer?: string) {
-		this.#bearer = bearer
+		this.#bearer = bearer;
 	}
 
 	public get httpAuthorizationHeader(): string | undefined {
@@ -113,22 +113,21 @@ export class OAuth2Authorization implements Authorization {
 	}
 
 	public get accessToken(): string | undefined {
-		return this.#bearer
+		return this.#bearer;
 	}
-
 
 	public get credentials(): { auth?: { username: string; password: string }; headers: Record<string, string> } | undefined {
 		if (this.resolved()) {
 			return {
 				headers: {
 					Authorization: this.httpAuthorizationHeader,
-				}
+				},
 			};
 		}
 	}
 
 	public clone(): OAuth2Authorization {
-		return new OAuth2Authorization(this.oauth2, this.#bearer)
+		return new OAuth2Authorization(this.oauth2, this.#bearer);
 	}
 }
 
@@ -165,7 +164,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 						return;
 					}
 
-					const params = [csp ? "csp" : "", project ? `project=${project}` : ""].filter(e => e != "").join("&");
+					const params = [csp ? "csp" : "", project ? `project=${project}` : ""].filter((e) => e != "").join("&");
 					const uri = vscode.Uri.parse(`isfs${readonly ? "-readonly" : ""}://${serverName}:${namespace}${csp && webApp ? webApp : "/"}${params ? `?${params}` : ""}`);
 					if ((vscode.workspace.workspaceFolders || []).filter((workspaceFolder) => workspaceFolder.uri.toString() === uri.toString()).length === 0) {
 						const label = `${project ? `${project} - ${serverName}:${namespace}` : !csp ? `${serverName}:${namespace}` : ["", "/"].includes(uri.path) ? `${serverName}:${namespace} web files` : `${serverName} (${uri.path})`}${readonly && project == undefined ? " (read-only)" : ""}`;
@@ -238,10 +237,10 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 					options.push(
 						{ label: "Workspace", detail: vscode.workspace.workspaceFile.toString(true), target: vscode.ConfigurationTarget.Workspace },
 						...vscode.workspace.workspaceFolders
-							.filter(f => !["isfs", "isfs-readonly"].includes(f.uri.scheme))
-							.map(f => {
+							.filter((f) => !["isfs", "isfs-readonly"].includes(f.uri.scheme))
+							.map((f) => {
 								return { label: f.name, detail: f.uri.toString(true), scope: f, target: vscode.ConfigurationTarget.WorkspaceFolder };
-							})
+							}),
 					);
 				} else {
 					// The workspace is a single local folder, so that is the only other option
@@ -249,9 +248,9 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				}
 				const choice = await vscode.window.showQuickPick(options, {
 					ignoreFocusOut: true,
-					title: "Pick a settings scope in which to add the server definition"
+					title: "Pick a settings scope in which to add the server definition",
 				});
-				if (!choice) return;
+				if (!choice) { return; }
 				scope = choice.scope;
 				target = choice.target;
 			} else {
@@ -334,13 +333,13 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				}
 			};
 			// Only WorkspaceFolder objects have an index.
-			if (server && servers?.workspaceFolderValue?.hasOwnProperty(server.name) && typeof (<vscode.WorkspaceFolder>scope)?.index == "number") {
+			if (server && servers?.workspaceFolderValue?.hasOwnProperty(server.name) && typeof (scope as vscode.WorkspaceFolder)?.index == "number") {
 				// Open the workspace folder settings file. Need to use showTextDocument because the
 				// "workbench.action.openFolderSettingsFile" command always prompts the user.
 				vscode.window.showTextDocument(
-					vscode.Uri.joinPath((<vscode.WorkspaceFolder>scope).uri, ".vscode", "settings.json"),
+					vscode.Uri.joinPath((scope as vscode.WorkspaceFolder).uri, ".vscode", "settings.json"),
 					// Need these two properties to mimic the workbench commands' behavior
-					{ preview: false, selection: new vscode.Range(0, 0, 0, 0) }
+					{ preview: false, selection: new vscode.Range(0, 0, 0, 0) },
 				).then(revealServer, () => {
 					// If there's an error, fall back to showing the UI
 					vscode.commands.executeCommand("workbench.action.openSettings", `@ext:${extensionId}`);
@@ -425,16 +424,16 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				await addWorkspaceFolderAsync(true, true, namespaceTreeItem);
 			}),
 		vscode.commands.registerCommand(`${extensionId}.editProject`, async (projectTreeItem?: ProjectTreeItem) => {
-			await addWorkspaceFolderAsync(false, false, <NamespaceTreeItem>projectTreeItem?.parent?.parent, projectTreeItem?.name);
+			await addWorkspaceFolderAsync(false, false, projectTreeItem?.parent?.parent as NamespaceTreeItem, projectTreeItem?.name);
 		}),
 		vscode.commands.registerCommand(`${extensionId}.viewProject`, async (projectTreeItem?: ProjectTreeItem) => {
-			await addWorkspaceFolderAsync(true, false, <NamespaceTreeItem>projectTreeItem?.parent?.parent, projectTreeItem?.name);
+			await addWorkspaceFolderAsync(true, false, projectTreeItem?.parent?.parent as NamespaceTreeItem, projectTreeItem?.name);
 		}),
 		vscode.commands.registerCommand(`${extensionId}.editWebApp`, async (webAppTreeItem?: WebAppTreeItem) => {
-			await addWorkspaceFolderAsync(false, true, <NamespaceTreeItem>webAppTreeItem?.parent?.parent, undefined, webAppTreeItem?.name);
+			await addWorkspaceFolderAsync(false, true, webAppTreeItem?.parent?.parent as NamespaceTreeItem, undefined, webAppTreeItem?.name);
 		}),
 		vscode.commands.registerCommand(`${extensionId}.viewWebApp`, async (webAppTreeItem?: WebAppTreeItem) => {
-			await addWorkspaceFolderAsync(true, true, <NamespaceTreeItem>webAppTreeItem?.parent?.parent, undefined, webAppTreeItem?.name);
+			await addWorkspaceFolderAsync(true, true, webAppTreeItem?.parent?.parent as NamespaceTreeItem, undefined, webAppTreeItem?.name);
 		}),
 		vscode.workspace.onDidChangeWorkspaceFolders(() => view.refreshTree()),
 		vscode.commands.registerCommand(`${extensionId}.signOut`, async () => {
@@ -444,7 +443,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				return;
 			}
 			const picks = await vscode.window.showQuickPick(sessions.map((s) => s.account), { canPickMany: true, title: "Pick the accounts to sign out of" });
-			if (!picks?.length) return;
+			if (!picks?.length) { return; }
 			return authProvider.removeSessions(picks.map((p) => p.id));
 		}),
 		// Listen for relevant configuration changes
@@ -452,7 +451,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			if (e.affectsConfiguration("intersystems.servers") || e.affectsConfiguration("objectscript.conn")) {
 				view.refreshTree();
 			}
-		})
+		}),
 	);
 
 	// Create our exported API
@@ -524,8 +523,8 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		},
 
 		defaultAuth(): Authorization {
-			return new PasswordAuthorization()
-		}
+			return new PasswordAuthorization();
+		},
 
 	};
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -106,7 +106,7 @@ export class OAuth2Authorization implements Authorization {
 	}
 
 	public get username(): string {
-		return this.#username ?? "OAuth2User";
+		return this.#username ?? "*OAuth2User*";
 	}
 
 	public get password(): undefined {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -22,8 +22,8 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 }
 
 export class PasswordAuthorization implements Authorization {
-	public #username?: string;
-	public #password?: string;
+	#username?: string;
+	#password?: string;
 	constructor(username?: string, password?: string) {
 		this.#username = username;
 		this.#password = password;
@@ -75,8 +75,8 @@ export class PasswordAuthorization implements Authorization {
 }
 
 export class OAuth2Authorization implements Authorization {
-	public #username?: string;
-	public #bearer?: string;
+	#username?: string;
+	#bearer?: string;
 	constructor(public readonly oauth2: OAuth2Config, bearer?: string) {
 		this.#bearer = bearer;
 	}

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -7,6 +7,7 @@ import { getServerSpec } from "./api/getServerSpec";
 import { getServerSummary } from "./api/getServerSummary";
 import { pickServer } from "./api/pickServer";
 import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./authenticationProvider";
+import { initLogger } from "./logger";
 import { logout, serverSessions } from "./makeRESTRequest";
 import { OAuth2Config } from "./serverSetting";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
@@ -140,6 +141,8 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 
 	// Other parts of this extension will use this to persist state
 	globalState = context.globalState;
+
+	initLogger(context);
 
 	/** Helper function for adding a workspace folder */
 	const addWorkspaceFolderAsync = async (readonly: boolean, csp: boolean, namespaceTreeItem?: ServerTreeItem, project?: string, webApp?: string) => {
@@ -444,7 +447,9 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			}
 			const picks = await vscode.window.showQuickPick(sessions.map((s) => s.account), { canPickMany: true, title: "Pick the accounts to sign out of" });
 			if (!picks?.length) { return; }
-			return authProvider.removeSessions(picks.map((p) => p.id));
+			// Map picked accounts back to session ids: account.id preserves username case whereas session.id lowercases it.
+			const pickedIds = new Set(picks.map((p) => p.id));
+			return authProvider.removeSessions(sessions.filter((s) => pickedIds.has(s.account.id)).map((s) => s.id));
 		}),
 		// Listen for relevant configuration changes
 		vscode.workspace.onDidChangeConfiguration((e) => {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -106,7 +106,7 @@ export class OAuth2Authorization implements Authorization {
 	}
 
 	public get username(): string {
-		return this.#username ?? "*OAuth2User*";
+		return this.#username ?? "*OAuth2*";
 	}
 
 	public get password(): undefined {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { Authorization, IServerName, IServerSpec, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
+import { Authorization, IServerName, IServerSpec, IServerSpecWithAuth, ResolvedAuthorization, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -500,14 +500,14 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		 * @param scope Settings scope to look in.
 		 * @param flushCredentialCache Obsolete, has no effect.
 		 * @param options
-		 * @returns { IServerSpec } Server specification object.
+		 * @returns { IServerSpecWithAuth } Server specification object.
 		 */
 		async getServerSpec(
 			name: string,
 			scope?: vscode.ConfigurationScope,
 			flushCredentialCache: boolean = false,
 			options?: { hideFromRecents?: boolean, /* Obsolete */ noCredentials?: boolean },
-		): Promise<IServerSpec | undefined> {
+		): Promise<IServerSpecWithAuth | undefined> {
 			const spec = await getServerSpec(name, scope);
 			if (spec === undefined) {
 				return undefined;

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -529,6 +529,10 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			return _onDidChangePassword.event;
 		},
 
+		defaultAuth(): Authorization {
+			return new PasswordAuthorization()
+		}
+
 	};
 
 	// 'export' the API

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -510,6 +510,9 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 				await view.addToRecents(name);
 			}
 
+			spec.auth = spec.auth.clone();
+			spec.auth.clear() as void;
+
 			return spec;
 		},
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -22,7 +22,7 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
 	return accountId ? { id: accountId, label: `${userName} on ${serverName}` } : undefined;
 }
 
-export class PasswordAuthorization implements Authorization {
+export class BasicAuthorization implements Authorization {
 	#username?: string;
 	#password?: string;
 	constructor(username?: string, password?: string) {
@@ -70,8 +70,8 @@ export class PasswordAuthorization implements Authorization {
 		};
 	}
 
-	public clone(): PasswordAuthorization {
-		return new PasswordAuthorization(this.#username, this.#password);
+	public clone(): BasicAuthorization {
+		return new BasicAuthorization(this.#username, this.#password);
 	}
 }
 
@@ -531,7 +531,7 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		},
 
 		defaultAuth(): Authorization {
-			return new PasswordAuthorization();
+			return new BasicAuthorization();
 		},
 
 	};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,9 +2,9 @@
 
 import * as vscode from "vscode";
 import { importFromRegistry } from "./commands/importFromRegistry";
-import { ServerManagerView } from "./ui/serverManagerView";
 import { commonActivate, extensionId } from "./commonActivate";
 import { logout, serverSessions } from "./makeRESTRequest";
+import { ServerManagerView } from "./ui/serverManagerView";
 
 export function activate(context: vscode.ExtensionContext) {
 	const view = new ServerManagerView(context);
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
 	// Do our best to log out of all sessions
 
-	const promises: Promise<void>[] = [];
+	const promises: Array<Promise<void>> = [];
 	for (const serverSession of serverSessions) {
 		promises.push(logout(serverSession[1].serverName));
 	}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,15 @@
+import * as vscode from "vscode";
+
+let channel: vscode.OutputChannel | undefined;
+
+/** Create the "Server Manager" output channel. Call once during activation. */
+export function initLogger(context: vscode.ExtensionContext): void {
+	if (!channel) {
+		channel = vscode.window.createOutputChannel("InterSystems Server Manager");
+		context.subscriptions.push(channel);
+	}
+}
+
+export function log(message: string): void {
+	channel?.appendLine(`[${new Date().toISOString()}] ${message}`);
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,15 +1,11 @@
 import * as vscode from "vscode";
 
-let channel: vscode.OutputChannel | undefined;
+export let logger: vscode.LogOutputChannel | undefined;
 
-/** Create the "Server Manager" output channel. Call once during activation. */
+/** Create the "InterSystems Server Manager" log channel. Call once during activation. */
 export function initLogger(context: vscode.ExtensionContext): void {
-	if (!channel) {
-		channel = vscode.window.createOutputChannel("InterSystems Server Manager");
-		context.subscriptions.push(channel);
+	if (!logger) {
+		logger = vscode.window.createOutputChannel("InterSystems Server Manager", { log: true });
+		context.subscriptions.push(logger);
 	}
-}
-
-export function log(message: string): void {
-	channel?.appendLine(`[${new Date().toISOString()}] ${message}`);
 }

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -6,7 +6,7 @@ import * as https from "https";
 import * as vscode from "vscode";
 import { getServerSpec } from "./api/getServerSpec";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { getAccountFromParts, OAuth2Authorization } from "./commonActivate";
+import { getAccountFromParts } from "./commonActivate";
 import { Authorization, IServerSpec, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export interface IServerSession {

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -154,14 +154,13 @@ export async function makeRESTRequest(
 			}
 		}
 
-		const authorization = server.auth;
 		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
 
 		// Only store the session for a serverName the first time because subsequent requests
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
 		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: authorization.username || "", cookies });
+			serverSessions.set(server.name, { serverName: server.name, username: server.auth.username || "", cookies });
 		} else {
 			serverSessions.set(server.name, { ...session, cookies });
 		}

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -164,7 +164,7 @@ export async function logout(serverName: string) {
 				httpsAgent,
 				method: "HEAD",
 				headers: {
-					Cookie: cookies.join(" "),
+					Cookie: cookies.join("; "),
 				},
 				url: encodeURI(url),
 				validateStatus: (status) => {

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -51,7 +51,7 @@ interface Credentials {
  * Make a REST request to an InterSystems server.
  *
  * @param method The REST method.
- * @param server The server setting to send the request to (internal type with OAuth2 config).
+ * @param server The server to send the request to.
  * @param endpoint Optional endpoint object. If omitted the request will be to /api/atelier/
  * @param data Optional request data. Usually passed for POST requests.
  */
@@ -101,22 +101,25 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				const credentials = await resolveCredentials(server) ?? {};
-				// There is a payload so we need to add content-type
-				credentials["headers"] = {
-					"Content-Type": "application/json",
-					...credentials["headers"],
-				};
-				respdata = await axios.request(
-					{
-						httpsAgent,
-						data,
-						method,
-						url: encodeURI(url),
-						withCredentials: true,
-						...credentials,
-					},
-				);
+				await resolveCredentials(server);
+				if (server.auth.resolved()) {
+					const credentials = server.auth.credentials;
+					// There is a payload so we need to add content-type
+					credentials["headers"] = {
+						"Content-Type": "application/json",
+						...credentials["headers"],
+					};
+					respdata = await axios.request(
+						{
+							httpsAgent,
+							...credentials,
+							data,
+							method,
+							url: encodeURI(url),
+							withCredentials: true,
+						},
+					);
+				}
 			}
 		} else {
 			// No data payload
@@ -135,16 +138,19 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				const credentials = await resolveCredentials(server) ?? {};
-				respdata = await axios.request(
-					{
-						httpsAgent,
-						method,
-						url: encodeURI(url),
-						withCredentials: true,
-						...credentials,
-					},
-				);
+				await resolveCredentials(server);
+				if (server.auth.resolved()) {
+					const credentials = server.auth.credentials;
+					respdata = await axios.request(
+						{
+							httpsAgent,
+							...credentials,
+							method,
+							url: encodeURI(url),
+							withCredentials: true,
+						},
+					);
+				}
 			}
 		}
 
@@ -212,12 +218,11 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(spec: IServerSpec): Promise<Credentials | undefined> {
+async function resolveCredentials(spec: IServerSpec): Promise<void> {
 	// Use authentication provider to get credentials when not already available
-	const authorization: Authorization = spec.auth;
-	if (!authorization.resolved()) {
-		const scopes = [spec.name, authorization.username];
-		const account = getAccountFromParts(spec.name, authorization.username);
+	if (!spec.auth.resolved()) {
+		const scopes = [spec.name, spec.auth.username];
+		const account = getAccountFromParts(spec.name, spec.auth.username);
 		let session = await vscode.authentication.getSession(
 			AUTHENTICATION_PROVIDER,
 			scopes,
@@ -231,16 +236,11 @@ async function resolveCredentials(spec: IServerSpec): Promise<Credentials | unde
 			);
 		}
 		if (session) {
-			authorization.resolve(
+			spec.auth.resolve(
 				session.accessToken,
 				session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
 			)
 		}
-	}
-	if (authorization.resolved()) {
-		return authorization.credentials
-	} else {
-		return;
 	}
 }
 

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -4,10 +4,10 @@
 import axios, { AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
-import { getServerSetting } from "./api/getServerSpec";
+import { getServerSpec } from "./api/getServerSpec";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { getAccountFromParts } from "./commonActivate";
-import { IServerSetting } from "./serverSetting";
+import { getAccountFromParts, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export interface IServerSession {
 	serverName: string;
@@ -36,24 +36,16 @@ function updateCookies(oldCookies: string[], newCookies: string[]): string[] {
 	return oldCookies;
 }
 
-function getCookies(server: IServerSetting): string[] {
+function getCookies(server: IServerSpec): string[] {
 	return serverSessions.get(server.name)?.cookies ?? [];
 }
-
-interface OAuth2Credentials {
-	headers: {
-		Authorization: string,
-	};
-}
-
-interface PasswordCredentials {
-	auth: {
+interface Credentials {
+	headers?: Record<string, string>;
+	auth?: {
 		password: string,
 		username: string,
 	};
-}
-
-type Credentials = OAuth2Credentials | PasswordCredentials;
+};
 
 /**
  * Make a REST request to an InterSystems server.
@@ -65,7 +57,7 @@ type Credentials = OAuth2Credentials | PasswordCredentials;
  */
 export async function makeRESTRequest(
 	method: "HEAD" | "GET" | "POST",
-	server: IServerSetting,
+	server: IServerSpec,
 	endpoint?: IAtelierRESTEndpoint,
 	data?: any,
 ): Promise<AxiosResponse> {
@@ -109,7 +101,7 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				const credentials = (await resolveCredentials(server)) || { headers: {} };
+				const credentials = await resolveCredentials(server) ?? {};
 				// There is a payload so we need to add content-type
 				credentials["headers"] = {
 					"Content-Type": "application/json",
@@ -143,7 +135,7 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				const credentials = await resolveCredentials(server);
+				const credentials = await resolveCredentials(server) ?? {};
 				respdata = await axios.request(
 					{
 						httpsAgent,
@@ -156,15 +148,18 @@ export async function makeRESTRequest(
 			}
 		}
 
-		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
+		const authorization = server.authorization;
+		if (authorization.resolved()) {
+			cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
 
-		// Only store the session for a serverName the first time because subsequent requests
-		// to a server with no username defined must not lose initially-recorded username
-		const session = serverSessions.get(server.name);
-		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: server['username'] ?? "", cookies });
-		} else {
-			serverSessions.set(server.name, { ...session, cookies });
+			// Only store the session for a serverName the first time because subsequent requests
+			// to a server with no username defined must not lose initially-recorded username
+			const session = serverSessions.get(server.name);
+			if (!session) {
+				serverSessions.set(server.name, { serverName: server.name, username: authorization.username || "", cookies });
+			} else {
+				serverSessions.set(server.name, { ...session, cookies });
+			}
 		}
 		return respdata;
 	} catch (error) {
@@ -180,7 +175,7 @@ export async function makeRESTRequest(
  */
 export async function logout(serverName: string) {
 
-	const server = await getServerSetting(serverName, undefined);
+	const server = await getServerSpec(serverName, undefined);
 
 	if (!server) {
 		return;
@@ -219,33 +214,33 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(setting: IServerSetting): Promise<Credentials | undefined> {
+async function resolveCredentials(spec: IServerSpec): Promise<Credentials | undefined> {
 	// Use authentication provider to get credentials when not already available
-	if ('oauth2' in setting) {
-		const account = getAccountFromParts(setting.name);
+	if (spec.authorization instanceof OAuth2Authorization) {
+		const account = getAccountFromParts(spec.name);
 		let session = await vscode.authentication.getSession(
 			AUTHENTICATION_PROVIDER,
-			[setting.name],
+			[spec.name],
 			{ silent: true, account },
 		);
 		if (!session) {
 			session = await vscode.authentication.getSession(
 				AUTHENTICATION_PROVIDER,
-				[setting.name],
+				[spec.name],
 				{ createIfNone: true, account },
 			);
 		}
 		if (!session) { return; }
-		return {
-			headers: { Authorization: `Bearer ${session.accessToken}` },
-		};
+		if (spec.authorization.resolve(session.accessToken)) {
+			return spec.authorization.credentials;
+		} else {
+			return;
+		}
 	}
-
-	// Password-based authentication
-	if (setting.password === undefined) {
-		const username = setting.username || "";
-		const scopes = [setting.name, username];
-		const account = getAccountFromParts(setting.name, username);
+	let authorization = spec.authorization as PasswordAuthorization;
+	if (!spec.authorization.resolved()) {
+		const scopes = [spec.name, authorization.username];
+		const account = getAccountFromParts(spec.name, authorization.username);
 		let session = await vscode.authentication.getSession(
 			AUTHENTICATION_PROVIDER,
 			scopes,
@@ -259,16 +254,17 @@ async function resolveCredentials(setting: IServerSetting): Promise<Credentials 
 			);
 		}
 		if (session) {
-			setting.username = session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1];
-			setting.password = session.accessToken;
+			authorization.resolve(
+				session.accessToken,
+				session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
+			)
 		}
 	}
-	return {
-		auth: {
-			username: setting.username ?? "",
-			password: setting.password ?? "",
-		},
-	};
+	if (authorization.resolved()) {
+		return authorization.credentials
+	} else {
+		return;
+	}
 }
 
 /**

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -226,10 +226,10 @@ async function resolveCredentials(spec: IServerSpec): Promise<void> {
 			);
 		}
 		if (session) {
-			spec.auth.resolve(
-				session.accessToken,
-				session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
-			)
+			spec.auth.resolve({
+				accessToken: session.accessToken,
+				username: session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
+			})
 		}
 	}
 }

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -57,7 +57,7 @@ interface Credentials {
  */
 export async function makeRESTRequest(
 	method: "HEAD" | "GET" | "POST",
-	server: IServerSpec & { authorization: ResolvedAuthorization },
+	server: IServerSpec,
 	endpoint?: IAtelierRESTEndpoint,
 	data?: any,
 ): Promise<AxiosResponse> {
@@ -148,7 +148,7 @@ export async function makeRESTRequest(
 			}
 		}
 
-		const authorization = server.authorization;
+		const authorization = server.auth;
 		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
 
 		// Only store the session for a serverName the first time because subsequent requests
@@ -212,9 +212,9 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(spec: IServerSpec & { authorization: ResolvedAuthorization }): Promise<Credentials | undefined> {
+async function resolveCredentials(spec: IServerSpec): Promise<Credentials | undefined> {
 	// Use authentication provider to get credentials when not already available
-	const authorization: Authorization = spec.authorization;
+	const authorization: Authorization = spec.auth;
 	if (!authorization.resolved()) {
 		const scopes = [spec.name, authorization.username];
 		const account = getAccountFromParts(spec.name, authorization.username);

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import { getServerSpec } from "./api/getServerSpec";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
 import { getAccountFromParts } from "./commonActivate";
-import { Authorization, IServerSpec, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export interface IServerSession {
 	serverName: string;
@@ -39,13 +39,6 @@ function updateCookies(oldCookies: string[], newCookies: string[]): string[] {
 function getCookies(server: IServerSpec): string[] {
 	return serverSessions.get(server.name)?.cookies ?? [];
 }
-interface Credentials {
-	headers?: Record<string, string>;
-	auth?: {
-		password: string,
-		username: string,
-	};
-};
 
 /**
  * Make a REST request to an InterSystems server.

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -4,10 +4,10 @@
 import axios, { AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
-import { getServerSpec } from "./api/getServerSpec";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { getAccountFromParts } from "./commonActivate";
 import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { getServerSpec } from "./api/getServerSpec";
+import { getAccountFromParts } from "./commonActivate";
 
 export interface IServerSession {
 	serverName: string;
@@ -94,17 +94,15 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
+				// Use AuthenticationProvider to get password (and possibly username) if not supplied by caller
 				await resolveCredentials(server);
 				if (server.auth.resolved()) {
-					const credentials = server.auth.credentials;
-					// There is a payload so we need to add content-type
-					credentials["headers"] = {
-						"Content-Type": "application/json",
-						...credentials["headers"],
-					};
+					// Either we had no cookies or they expired, so resend the request with basic auth
+					const { headers, ...credentials } = server.auth.credentials;
 					respdata = await axios.request(
 						{
 							httpsAgent,
+							headers: { ...headers, "Content-Type": "application/json" },
 							...credentials,
 							data,
 							method,
@@ -131,13 +129,13 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
+				// Use AuthenticationProvider to get password (and possibly username) if not supplied by caller
 				await resolveCredentials(server);
 				if (server.auth.resolved()) {
-					const credentials = server.auth.credentials;
 					respdata = await axios.request(
 						{
 							httpsAgent,
-							...credentials,
+							...server.auth.credentials,
 							method,
 							url: encodeURI(url),
 							withCredentials: true,
@@ -211,7 +209,7 @@ export async function logout(serverName: string) {
 }
 
 async function resolveCredentials(spec: IServerSpec): Promise<void> {
-	// Use authentication provider to get credentials when not already available
+	// This arises if setting says to use authentication provider
 	if (!spec.auth.resolved()) {
 		const scopes = [spec.name, spec.auth.username];
 		const account = getAccountFromParts(spec.name, spec.auth.username);

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -1,12 +1,12 @@
 // Derived from
 //  https://github.com/intersystems/language-server/blob/bdeea88d1900a3aff35d5ac373436899f3904a7e/server/src/server.ts
 
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import axios, { AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
-import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { getServerSpec } from "./api/getServerSpec";
+import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
 import { getAccountFromParts } from "./commonActivate";
 
 export interface IServerSession {
@@ -43,14 +43,14 @@ function getCookies(server: IServerSpec): string[] {
 interface OAuth2Credentials {
 	headers: {
 		Authorization: string,
-	},
+	};
 }
 
 interface PasswordCredentials {
 	auth: {
 		password: string,
 		username: string,
-	},
+	};
 }
 
 type Credentials = OAuth2Credentials | PasswordCredentials;
@@ -98,7 +98,7 @@ export async function makeRESTRequest(
 					data,
 					headers: {
 						"Content-Type": "application/json",
-						"Cookie": cookies.join(" ")
+						"Cookie": cookies.join(" "),
 					},
 					method,
 					url: encodeURI(url),
@@ -111,9 +111,9 @@ export async function makeRESTRequest(
 			if (respdata.status === 401) {
 				const credentials = (await resolveCredentials(server)) || { headers: {} };
 				// There is a payload so we need to add content-type
-				credentials["headers"] = {
+				credentials.headers = {
 					"Content-Type": "application/json",
-					...credentials["headers"]
+					...credentials.headers,
 				};
 				respdata = await axios.request(
 					{
@@ -133,7 +133,7 @@ export async function makeRESTRequest(
 					httpsAgent,
 					method,
 					headers: {
-						"Cookie": cookies.join(" ")
+						Cookie: cookies.join(" "),
 					},
 					url: encodeURI(url),
 					validateStatus: (status) => {
@@ -143,7 +143,7 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				let credentials = await resolveCredentials(server);
+				const credentials = await resolveCredentials(server);
 				respdata = await axios.request(
 					{
 						httpsAgent,
@@ -156,13 +156,13 @@ export async function makeRESTRequest(
 			}
 		}
 
-		cookies = updateCookies(cookies, respdata.headers['set-cookie'] || []);
+		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
 
 		// Only store the session for a serverName the first time because subsequent requests
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
 		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: server.username || '', cookies });
+			serverSessions.set(server.name, { serverName: server.name, username: server.username || "", cookies });
 		} else {
 			serverSessions.set(server.name, { ...session, cookies });
 		}
@@ -190,7 +190,7 @@ export async function logout(serverName: string) {
 	const httpsAgent = typeof https.Agent == "function" ? new https.Agent({ rejectUnauthorized: vscode.workspace.getConfiguration("http").get("proxyStrictSSL") }) : undefined;
 
 	// Get the cookies
-	let cookies: string[] = getCookies(server);
+	const cookies: string[] = getCookies(server);
 
 	// Build the URL
 	let url = server.webServer.scheme + "://" + server.webServer.host + ":" + String(server.webServer.port);
@@ -207,7 +207,7 @@ export async function logout(serverName: string) {
 				httpsAgent,
 				method: "HEAD",
 				headers: {
-					"Cookie": cookies.join(" ")
+					Cookie: cookies.join(" "),
 				},
 				url: encodeURI(url),
 				validateStatus: (status) => {
@@ -235,10 +235,10 @@ async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials 
 				{ createIfNone: true, account },
 			);
 		}
-		if (!session) return;
+		if (!session) { return; }
 		return {
-			headers: { "Authorization": `Bearer ${session.accessToken}` }
-		}
+			headers: { Authorization: `Bearer ${session.accessToken}` },
+		};
 	}
 
 	// Password-based authentication
@@ -265,9 +265,9 @@ async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials 
 	return {
 		auth: {
 			username: serverSpec.username ?? "",
-			password: serverSpec.password ?? ""
-		}
-	}
+			password: serverSpec.password ?? "",
+		},
+	};
 }
 
 /**

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -162,7 +162,7 @@ export async function makeRESTRequest(
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
 		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: server["username"] || '', cookies });
+			serverSessions.set(server.name, { serverName: server.name, username: server.username || '', cookies });
 		} else {
 			serverSessions.set(server.name, { ...session, cookies });
 		}

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -111,9 +111,9 @@ export async function makeRESTRequest(
 			if (respdata.status === 401) {
 				const credentials = (await resolveCredentials(server)) || { headers: {} };
 				// There is a payload so we need to add content-type
-				credentials.headers = {
+				credentials["headers"] = {
 					"Content-Type": "application/json",
-					...credentials.headers,
+					...credentials["headers"],
 				};
 				respdata = await axios.request(
 					{

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -40,6 +40,21 @@ function getCookies(server: IServerSpec): string[] {
 	return serverSessions.get(server.name)?.cookies ?? [];
 }
 
+interface OAuth2Credentials {
+	headers: {
+		Authorization: string,
+	},
+}
+
+interface PasswordCredentials {
+	auth: {
+		password: string,
+		username: string,
+	},
+}
+
+type Credentials = OAuth2Credentials | PasswordCredentials;
+
 /**
  * Make a REST request to an InterSystems server.
  *
@@ -94,42 +109,22 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				await resolveCredentials(server);
-				const isOAuth2 = (server as any).authMethod === "oauth2";
-				if (isOAuth2 && typeof server.password !== "undefined") {
-					// Resend with Bearer token (JWT from OAuth2 flow)
-					respdata = await axios.request(
-						{
-							httpsAgent,
-							data,
-							headers: {
-								"Content-Type": "application/json",
-								"Authorization": `Bearer ${server.password}`,
-							},
-							method,
-							url: encodeURI(url),
-							withCredentials: true,
-						},
-					);
-				} else if (typeof server.username !== "undefined" && typeof server.password !== "undefined") {
-					// Either we had no cookies or they expired, so resend the request with basic auth
-					respdata = await axios.request(
-						{
-							httpsAgent,
-							auth: {
-								password: server.password,
-								username: server.username,
-							},
-							data,
-							headers: {
-								"Content-Type": "application/json",
-							},
-							method,
-							url: encodeURI(url),
-							withCredentials: true,
-						},
-					);
-				}
+				const credentials = (await resolveCredentials(server)) || { headers: {} };
+				// There is a payload so we need to add content-type
+				credentials["headers"] = {
+					"Content-Type": "application/json",
+					...credentials["headers"]
+				};
+				respdata = await axios.request(
+					{
+						httpsAgent,
+						data,
+						method,
+						url: encodeURI(url),
+						withCredentials: true,
+						...credentials,
+					},
+				);
 			}
 		} else {
 			// No data payload
@@ -148,36 +143,16 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				await resolveCredentials(server);
-				const isOAuth2 = (server as any).authMethod === "oauth2";
-				if (isOAuth2 && typeof server.password !== "undefined") {
-					// Resend with Bearer token (JWT from OAuth2 flow)
-					respdata = await axios.request(
-						{
-							httpsAgent,
-							method,
-							headers: {
-								"Authorization": `Bearer ${server.password}`,
-							},
-							url: encodeURI(url),
-							withCredentials: true,
-						},
-					);
-				} else if (typeof server.username !== "undefined" && typeof server.password !== "undefined") {
-					// Either we had no cookies or they expired, so resend the request with basic auth
-					respdata = await axios.request(
-						{
-							httpsAgent,
-							auth: {
-								password: server.password,
-								username: server.username,
-							},
-							method,
-							url: encodeURI(url),
-							withCredentials: true,
-						},
-					);
-				}
+				let credentials = await resolveCredentials(server);
+				respdata = await axios.request(
+					{
+						httpsAgent,
+						method,
+						url: encodeURI(url),
+						withCredentials: true,
+						...credentials,
+					},
+				);
 			}
 		}
 
@@ -187,7 +162,7 @@ export async function makeRESTRequest(
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
 		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: server.username || '', cookies });
+			serverSessions.set(server.name, { serverName: server.name, username: server["username"] || '', cookies });
 		} else {
 			serverSessions.set(server.name, { ...session, cookies });
 		}
@@ -244,17 +219,37 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(serverSpec: IServerSpec) {
+async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials | undefined> {
 	// Use authentication provider to get credentials when not already available
+	if (serverSpec.authMethod === "oauth2") {
+		const account = getAccountFromParts(serverSpec.name);
+		let session = await vscode.authentication.getSession(
+			AUTHENTICATION_PROVIDER,
+			[serverSpec.name],
+			{ silent: true, account },
+		);
+		if (!session) {
+			session = await vscode.authentication.getSession(
+				AUTHENTICATION_PROVIDER,
+				[serverSpec.name],
+				{ createIfNone: true, account },
+			);
+		}
+		if (!session) return;
+		return {
+			headers: { "Authorization": `Bearer ${session.accessToken}` }
+		}
+	}
+
+	// Password-based authentication
 	if (typeof serverSpec.password === "undefined") {
 		// Fetch full server spec to get authMethod (may not be on the passed-in object)
 		const fullSpec = await getServerSpec(serverSpec.name, undefined);
 		if (fullSpec && (fullSpec as any).authMethod) {
-			(serverSpec as any).authMethod = (fullSpec as any).authMethod;
+			serverSpec.authMethod = (fullSpec as any).authMethod;
 		}
 
 		// Request session from authentication provider
-		// For OAuth2: accessToken is the JWT, username is "OAuth2User"
 		// For password: accessToken is the password, username is the actual username
 		const scopes = [serverSpec.name, (serverSpec.username || "")];
 		const account = getAccountFromParts(serverSpec.name, serverSpec.username);
@@ -273,6 +268,12 @@ async function resolveCredentials(serverSpec: IServerSpec) {
 		if (session) {
 			serverSpec.username = session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1];
 			serverSpec.password = session.accessToken;
+		}
+	}
+	return {
+		auth: {
+			username: serverSpec.username ?? "",
+			password: serverSpec.password ?? ""
 		}
 	}
 }

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -94,9 +94,24 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				// Use AuthenticationProvider to get password (and possibly username) if not supplied by caller
 				await resolveCredentials(server);
-				if (typeof server.username !== "undefined" && typeof server.password !== "undefined") {
+				const isOAuth2 = (server as any).authMethod === "oauth2";
+				if (isOAuth2 && typeof server.password !== "undefined") {
+					// Resend with Bearer token (JWT from OAuth2 flow)
+					respdata = await axios.request(
+						{
+							httpsAgent,
+							data,
+							headers: {
+								"Content-Type": "application/json",
+								"Authorization": `Bearer ${server.password}`,
+							},
+							method,
+							url: encodeURI(url),
+							withCredentials: true,
+						},
+					);
+				} else if (typeof server.username !== "undefined" && typeof server.password !== "undefined") {
 					// Either we had no cookies or they expired, so resend the request with basic auth
 					respdata = await axios.request(
 						{
@@ -133,9 +148,22 @@ export async function makeRESTRequest(
 				},
 			);
 			if (respdata.status === 401) {
-				// Use AuthenticationProvider to get password (and possibly username) if not supplied by caller
 				await resolveCredentials(server);
-				if (typeof server.username !== "undefined" && typeof server.password !== "undefined") {
+				const isOAuth2 = (server as any).authMethod === "oauth2";
+				if (isOAuth2 && typeof server.password !== "undefined") {
+					// Resend with Bearer token (JWT from OAuth2 flow)
+					respdata = await axios.request(
+						{
+							httpsAgent,
+							method,
+							headers: {
+								"Authorization": `Bearer ${server.password}`,
+							},
+							url: encodeURI(url),
+							withCredentials: true,
+						},
+					);
+				} else if (typeof server.username !== "undefined" && typeof server.password !== "undefined") {
 					// Either we had no cookies or they expired, so resend the request with basic auth
 					respdata = await axios.request(
 						{
@@ -217,8 +245,17 @@ export async function logout(serverName: string) {
 }
 
 async function resolveCredentials(serverSpec: IServerSpec) {
-	// This arises if setting says to use authentication provider
+	// Use authentication provider to get credentials when not already available
 	if (typeof serverSpec.password === "undefined") {
+		// Fetch full server spec to get authMethod (may not be on the passed-in object)
+		const fullSpec = await getServerSpec(serverSpec.name, undefined);
+		if (fullSpec && (fullSpec as any).authMethod) {
+			(serverSpec as any).authMethod = (fullSpec as any).authMethod;
+		}
+
+		// Request session from authentication provider
+		// For OAuth2: accessToken is the JWT, username is "OAuth2User"
+		// For password: accessToken is the password, username is the actual username
 		const scopes = [serverSpec.name, (serverSpec.username || "")];
 		const account = getAccountFromParts(serverSpec.name, serverSpec.username);
 		let session = await vscode.authentication.getSession(

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -6,8 +6,8 @@ import * as https from "https";
 import * as vscode from "vscode";
 import { getServerSpec } from "./api/getServerSpec";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { getAccountFromParts, OAuth2Authorization, PasswordAuthorization } from "./commonActivate";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { getAccountFromParts, OAuth2Authorization } from "./commonActivate";
+import { Authorization, IServerSpec, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export interface IServerSession {
 	serverName: string;
@@ -57,7 +57,7 @@ interface Credentials {
  */
 export async function makeRESTRequest(
 	method: "HEAD" | "GET" | "POST",
-	server: IServerSpec,
+	server: IServerSpec & { authorization: ResolvedAuthorization },
 	endpoint?: IAtelierRESTEndpoint,
 	data?: any,
 ): Promise<AxiosResponse> {
@@ -149,17 +149,15 @@ export async function makeRESTRequest(
 		}
 
 		const authorization = server.authorization;
-		if (authorization.resolved()) {
-			cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
+		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
 
-			// Only store the session for a serverName the first time because subsequent requests
-			// to a server with no username defined must not lose initially-recorded username
-			const session = serverSessions.get(server.name);
-			if (!session) {
-				serverSessions.set(server.name, { serverName: server.name, username: authorization.username || "", cookies });
-			} else {
-				serverSessions.set(server.name, { ...session, cookies });
-			}
+		// Only store the session for a serverName the first time because subsequent requests
+		// to a server with no username defined must not lose initially-recorded username
+		const session = serverSessions.get(server.name);
+		if (!session) {
+			serverSessions.set(server.name, { serverName: server.name, username: authorization.username || "", cookies });
+		} else {
+			serverSessions.set(server.name, { ...session, cookies });
 		}
 		return respdata;
 	} catch (error) {
@@ -214,31 +212,10 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(spec: IServerSpec): Promise<Credentials | undefined> {
+async function resolveCredentials(spec: IServerSpec & { authorization: ResolvedAuthorization }): Promise<Credentials | undefined> {
 	// Use authentication provider to get credentials when not already available
-	if (spec.authorization instanceof OAuth2Authorization) {
-		const account = getAccountFromParts(spec.name);
-		let session = await vscode.authentication.getSession(
-			AUTHENTICATION_PROVIDER,
-			[spec.name],
-			{ silent: true, account },
-		);
-		if (!session) {
-			session = await vscode.authentication.getSession(
-				AUTHENTICATION_PROVIDER,
-				[spec.name],
-				{ createIfNone: true, account },
-			);
-		}
-		if (!session) { return; }
-		if (spec.authorization.resolve(session.accessToken)) {
-			return spec.authorization.credentials;
-		} else {
-			return;
-		}
-	}
-	let authorization = spec.authorization as PasswordAuthorization;
-	if (!spec.authorization.resolved()) {
+	const authorization: Authorization = spec.authorization;
+	if (!authorization.resolved()) {
 		const scopes = [spec.name, authorization.username];
 		const account = getAccountFromParts(spec.name, authorization.username);
 		let session = await vscode.authentication.getSession(

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -1,7 +1,7 @@
 // Derived from
 //  https://github.com/intersystems/language-server/blob/bdeea88d1900a3aff35d5ac373436899f3904a7e/server/src/server.ts
 
-import axios, { AxiosResponse } from "axios";
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
@@ -72,81 +72,49 @@ export async function makeRESTRequest(
 		url += "v" + String(endpoint.apiVersion) + "/" + endpoint.namespace + endpoint.path;
 	}
 
+
+	const request: AxiosRequestConfig & { headers: {} } = {
+		httpsAgent,
+		headers: {},
+		method,
+		url: encodeURI(url),
+		validateStatus: (status) => {
+			return status < 500;
+		},
+		withCredentials: true,
+	};
+	if (data !== undefined) {
+		request["headers"]["Content-Type"] = "application/json";
+		request["data"] = data
+	}
+
 	// Make the request
 	try {
-		let respdata: AxiosResponse;
-		if (data !== undefined) {
-			// There is a data payload
+		let respdata;
+		// Cookie attempt
+		if (cookies.length > 0) {
+			request.headers["Cookie"] = cookies.join("; ")
 			respdata = await axios.request(
-				{
-					httpsAgent,
-					data,
-					headers: {
-						"Content-Type": "application/json",
-						"Cookie": cookies.join(" "),
-					},
-					method,
-					url: encodeURI(url),
-					validateStatus: (status) => {
-						return status < 500;
-					},
-					withCredentials: true,
-				},
+				request,
 			);
-			if (respdata.status === 401) {
-				// Use AuthenticationProvider to get password (and possibly username) if not supplied by caller
-				await resolveCredentials(server);
-				if (server.auth.resolved()) {
-					// Either we had no cookies or they expired, so resend the request with basic auth
-					const { headers, ...credentials } = server.auth.credentials;
-					respdata = await axios.request(
-						{
-							httpsAgent,
-							headers: { ...headers, "Content-Type": "application/json" },
-							...credentials,
-							data,
-							method,
-							url: encodeURI(url),
-							withCredentials: true,
-						},
-					);
-				}
-			}
-		} else {
-			// No data payload
-			respdata = await axios.request(
-				{
-					httpsAgent,
-					method,
-					headers: {
-						Cookie: cookies.join(" "),
-					},
-					url: encodeURI(url),
-					validateStatus: (status) => {
-						return status < 500;
-					},
-					withCredentials: true,
-				},
-			);
-			if (respdata.status === 401) {
-				// Use AuthenticationProvider to get password (and possibly username) if not supplied by caller
-				await resolveCredentials(server);
-				if (server.auth.resolved()) {
-					respdata = await axios.request(
-						{
-							httpsAgent,
-							...server.auth.credentials,
-							method,
-							url: encodeURI(url),
-							withCredentials: true,
-						},
-					);
-				}
+			if (respdata?.status === 401) {
+				delete request.headers["Cookie"]
+				respdata = undefined;
 			}
 		}
-
+		// Credential attempt
+		if (respdata === undefined) {
+			await resolveCredentials(server);
+			if (server.auth.resolved()) {
+				for (const [k, v] of Object.entries(server.auth.credentials)) {
+					request[k] = Object.assign({}, request[k], v)
+				}
+				respdata = await axios.request(request);
+			} else {
+				throw Error("Internal error: Credentials were not resolved")
+			}
+		}
 		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
-
 		// Only store the session for a serverName the first time because subsequent requests
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
@@ -225,12 +193,16 @@ async function resolveCredentials(spec: IServerSpec): Promise<void> {
 				{ createIfNone: true, account },
 			);
 		}
-		if (session) {
+		if (session && session.accessToken) {
+			const username = session.scopes[1];
 			spec.auth.resolve({
 				accessToken: session.accessToken,
-				username: session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
+				username: username?.toLowerCase() !== "unknownuser" ? (username || "") : "",
 			})
 		}
+	}
+	if (!spec.auth.resolved()) {
+		throw new Error("Internal error: Credentials were not resolved");
 	}
 }
 

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -1,13 +1,13 @@
 // Derived from
 //  https://github.com/intersystems/language-server/blob/bdeea88d1900a3aff35d5ac373436899f3904a7e/server/src/server.ts
 
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import axios, { AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
-import { getServerSpec } from "./api/getServerSpec";
+import { getServerSetting } from "./api/getServerSpec";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
 import { getAccountFromParts } from "./commonActivate";
+import { IServerSetting } from "./serverSetting";
 
 export interface IServerSession {
 	serverName: string;
@@ -36,7 +36,7 @@ function updateCookies(oldCookies: string[], newCookies: string[]): string[] {
 	return oldCookies;
 }
 
-function getCookies(server: IServerSpec): string[] {
+function getCookies(server: IServerSetting): string[] {
 	return serverSessions.get(server.name)?.cookies ?? [];
 }
 
@@ -59,13 +59,13 @@ type Credentials = OAuth2Credentials | PasswordCredentials;
  * Make a REST request to an InterSystems server.
  *
  * @param method The REST method.
- * @param server The server to send the request to.
+ * @param server The server setting to send the request to (internal type with OAuth2 config).
  * @param endpoint Optional endpoint object. If omitted the request will be to /api/atelier/
  * @param data Optional request data. Usually passed for POST requests.
  */
 export async function makeRESTRequest(
 	method: "HEAD" | "GET" | "POST",
-	server: IServerSpec,
+	server: IServerSetting,
 	endpoint?: IAtelierRESTEndpoint,
 	data?: any,
 ): Promise<AxiosResponse> {
@@ -162,7 +162,7 @@ export async function makeRESTRequest(
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
 		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: server.username || "", cookies });
+			serverSessions.set(server.name, { serverName: server.name, username: server['username'] ?? "", cookies });
 		} else {
 			serverSessions.set(server.name, { ...session, cookies });
 		}
@@ -180,7 +180,7 @@ export async function makeRESTRequest(
  */
 export async function logout(serverName: string) {
 
-	const server = await getServerSpec(serverName, undefined);
+	const server = await getServerSetting(serverName, undefined);
 
 	if (!server) {
 		return;
@@ -219,19 +219,19 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials | undefined> {
+async function resolveCredentials(setting: IServerSetting): Promise<Credentials | undefined> {
 	// Use authentication provider to get credentials when not already available
-	if (serverSpec.authMethod === "oauth2") {
-		const account = getAccountFromParts(serverSpec.name);
+	if ('oauth2' in setting) {
+		const account = getAccountFromParts(setting.name);
 		let session = await vscode.authentication.getSession(
 			AUTHENTICATION_PROVIDER,
-			[serverSpec.name],
+			[setting.name],
 			{ silent: true, account },
 		);
 		if (!session) {
 			session = await vscode.authentication.getSession(
 				AUTHENTICATION_PROVIDER,
-				[serverSpec.name],
+				[setting.name],
 				{ createIfNone: true, account },
 			);
 		}
@@ -242,9 +242,10 @@ async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials 
 	}
 
 	// Password-based authentication
-	if (serverSpec.password === undefined) {
-		const scopes = [serverSpec.name, (serverSpec.username || "")];
-		const account = getAccountFromParts(serverSpec.name, serverSpec.username);
+	if (setting.password === undefined) {
+		const username = setting.username || "";
+		const scopes = [setting.name, username];
+		const account = getAccountFromParts(setting.name, username);
 		let session = await vscode.authentication.getSession(
 			AUTHENTICATION_PROVIDER,
 			scopes,
@@ -258,14 +259,14 @@ async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials 
 			);
 		}
 		if (session) {
-			serverSpec.username = session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1];
-			serverSpec.password = session.accessToken;
+			setting.username = session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1];
+			setting.password = session.accessToken;
 		}
 	}
 	return {
 		auth: {
-			username: serverSpec.username ?? "",
-			password: serverSpec.password ?? "",
+			username: setting.username ?? "",
+			password: setting.password ?? "",
 		},
 	};
 }

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -242,15 +242,7 @@ async function resolveCredentials(serverSpec: IServerSpec): Promise<Credentials 
 	}
 
 	// Password-based authentication
-	if (typeof serverSpec.password === "undefined") {
-		// Fetch full server spec to get authMethod (may not be on the passed-in object)
-		const fullSpec = await getServerSpec(serverSpec.name, undefined);
-		if (fullSpec && (fullSpec as any).authMethod) {
-			serverSpec.authMethod = (fullSpec as any).authMethod;
-		}
-
-		// Request session from authentication provider
-		// For password: accessToken is the password, username is the actual username
+	if (serverSpec.password === undefined) {
 		const scopes = [serverSpec.name, (serverSpec.username || "")];
 		const account = getAccountFromParts(serverSpec.name, serverSpec.username);
 		let session = await vscode.authentication.getSession(

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -1,12 +1,12 @@
 // Derived from
 //  https://github.com/intersystems/language-server/blob/bdeea88d1900a3aff35d5ac373436899f3904a7e/server/src/server.ts
 
+import { IServerSpec, IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
-import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { IServerSpec, IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
 import { getServerSpec } from "./api/getServerSpec";
+import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
 import { getAccountFromParts } from "./commonActivate";
 
 export interface IServerSession {
@@ -72,7 +72,6 @@ export async function makeRESTRequest(
 		url += "v" + String(endpoint.apiVersion) + "/" + endpoint.namespace + endpoint.path;
 	}
 
-
 	const request: AxiosRequestConfig & { headers: {}, data?: any } = {
 		httpsAgent,
 		headers: {},
@@ -85,19 +84,19 @@ export async function makeRESTRequest(
 	};
 	if (data !== undefined) {
 		request.headers["Content-Type"] = "application/json";
-		request.data = data
+		request.data = data;
 	}
 	// Make the request
 	try {
 		let respdata;
 		// Make the request w/ cookies if applicable
 		if (cookies.length > 0) {
-			request.headers["Cookie"] = cookies.join("; ")
+			request.headers.Cookie = cookies.join("; ");
 			respdata = await axios.request(
 				request,
 			);
 			if (respdata?.status === 401) {
-				delete request.headers["Cookie"]
+				delete request.headers.Cookie;
 				respdata = undefined;
 			}
 		}
@@ -105,13 +104,13 @@ export async function makeRESTRequest(
 		if (respdata === undefined) {
 			await resolveCredentials(server);
 			if (!server.auth.resolved()) {
-				throw Error("Internal error: Credentials were not resolved")
+				throw Error("Internal error: Credentials were not resolved");
 			}
 			for (const [k, v] of Object.entries(server.auth.credentials)) {
 				if (typeof v === "object") {
-					request[k] = Object.assign({}, request[k], v)
+					request[k] = Object.assign({}, request[k], v);
 				} else {
-					request[k] = v
+					request[k] = v;
 				}
 			}
 			respdata = await axios.request(request);
@@ -199,7 +198,7 @@ async function resolveCredentials(spec: IServerSpecWithAuth): Promise<void> {
 			spec.auth.resolve({
 				accessToken: session.accessToken,
 				username: session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
-			})
+			});
 		}
 	}
 }

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -165,7 +165,7 @@ export async function logout(serverName: string) {
 				httpsAgent,
 				method: "HEAD",
 				headers: {
-					Cookie: cookies.join("; "),
+					Cookie: cookies.join(" "),
 				},
 				url: encodeURI(url),
 				validateStatus: (status) => {

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -121,7 +121,7 @@ export async function makeRESTRequest(
 		// to a server with no username defined must not lose initially-recorded username
 		const session = serverSessions.get(server.name);
 		if (!session) {
-			serverSessions.set(server.name, { serverName: server.name, username: server.auth.username || "", cookies });
+			serverSessions.set(server.name, { serverName: server.name, username: server.auth.username, cookies });
 		} else {
 			serverSessions.set(server.name, { ...session, cookies });
 		}

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -196,15 +196,11 @@ async function resolveCredentials(spec: IServerSpec): Promise<void> {
 			);
 		}
 		if (session && session.accessToken) {
-			const username = session.scopes[1];
 			spec.auth.resolve({
 				accessToken: session.accessToken,
-				username: username?.toLowerCase() !== "unknownuser" ? (username || "") : "",
+				username: session.scopes[1].toLowerCase() === "unknownuser" ? "" : session.scopes[1],
 			})
 		}
-	}
-	if (!spec.auth.resolved()) {
-		throw new Error("Internal error: Credentials were not resolved");
 	}
 }
 

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -5,7 +5,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
 import { AUTHENTICATION_PROVIDER } from "./authenticationProvider";
-import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerSpec, IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
 import { getServerSpec } from "./api/getServerSpec";
 import { getAccountFromParts } from "./commonActivate";
 
@@ -50,7 +50,7 @@ function getCookies(server: IServerSpec): string[] {
  */
 export async function makeRESTRequest(
 	method: "HEAD" | "GET" | "POST",
-	server: IServerSpec,
+	server: IServerSpecWithAuth,
 	endpoint?: IAtelierRESTEndpoint,
 	data?: any,
 ): Promise<AxiosResponse> {
@@ -178,7 +178,7 @@ export async function logout(serverName: string) {
 	} catch { }
 }
 
-async function resolveCredentials(spec: IServerSpec): Promise<void> {
+async function resolveCredentials(spec: IServerSpecWithAuth): Promise<void> {
 	// This arises if setting says to use authentication provider
 	if (!spec.auth.resolved()) {
 		const scopes = [spec.name, spec.auth.username];

--- a/src/makeRESTRequest.ts
+++ b/src/makeRESTRequest.ts
@@ -73,7 +73,7 @@ export async function makeRESTRequest(
 	}
 
 
-	const request: AxiosRequestConfig & { headers: {} } = {
+	const request: AxiosRequestConfig & { headers: {}, data?: any } = {
 		httpsAgent,
 		headers: {},
 		method,
@@ -84,14 +84,13 @@ export async function makeRESTRequest(
 		withCredentials: true,
 	};
 	if (data !== undefined) {
-		request["headers"]["Content-Type"] = "application/json";
-		request["data"] = data
+		request.headers["Content-Type"] = "application/json";
+		request.data = data
 	}
-
 	// Make the request
 	try {
 		let respdata;
-		// Cookie attempt
+		// Make the request w/ cookies if applicable
 		if (cookies.length > 0) {
 			request.headers["Cookie"] = cookies.join("; ")
 			respdata = await axios.request(
@@ -102,17 +101,20 @@ export async function makeRESTRequest(
 				respdata = undefined;
 			}
 		}
-		// Credential attempt
+		// Make the request w/ credentials
 		if (respdata === undefined) {
 			await resolveCredentials(server);
-			if (server.auth.resolved()) {
-				for (const [k, v] of Object.entries(server.auth.credentials)) {
-					request[k] = Object.assign({}, request[k], v)
-				}
-				respdata = await axios.request(request);
-			} else {
+			if (!server.auth.resolved()) {
 				throw Error("Internal error: Credentials were not resolved")
 			}
+			for (const [k, v] of Object.entries(server.auth.credentials)) {
+				if (typeof v === "object") {
+					request[k] = Object.assign({}, request[k], v)
+				} else {
+					request[k] = v
+				}
+			}
+			respdata = await axios.request(request);
 		}
 		cookies = updateCookies(cookies, respdata.headers["set-cookie"] || []);
 		// Only store the session for a serverName the first time because subsequent requests

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -111,7 +111,10 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 		}).toString(), {
 			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		});
-
+		if (!tokenResponse.data.access_token) {
+			vscode.window.showErrorMessage("OAuth2: No access token in response");
+			return undefined;
+		}
 		return tokenResponse.data.access_token;
 	} catch (err: any) {
 		const detail = err.response?.data?.error_description || err.message;

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -44,6 +44,7 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 	// - "openid": required by OIDC spec, triggers ID token issuance
 	// - "profile": includes user's name/picture in claims
 	// - "email": includes user's email in claims
+	// It is standard to pass those scopes althought we don't need them
 	const scopes = ["openid", "profile", "email"];
 	const authUrl = new URL(authorizationEndpoint);
 	authUrl.searchParams.set("client_id", config.clientId);

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -66,6 +66,7 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 				const error = query.get("error");
 
 				disposable.dispose();
+				clearTimeout(timeoutHandle);
 
 				if (error) {
 					vscode.window.showErrorMessage(`OAuth2 error: ${error} - ${query.get("error_description") || ""}`, { modal: true });
@@ -82,7 +83,7 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 		});
 
 		// Auto-cancel after 2 minutes
-		setTimeout(() => {
+		const timeoutHandle = setTimeout(() => {
 			disposable.dispose();
 			vscode.window.showWarningMessage("OAuth2: Login timed out. Please try again.", { modal: true });
 			resolve(undefined);

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -1,0 +1,146 @@
+import axios from "axios";
+import * as vscode from "vscode";
+
+export interface IOAuth2Config {
+	authority: string;
+	clientId: string;
+	audience: string;
+}
+
+/**
+ * Perform an OAuth2 Authorization Code + PKCE flow.
+ * Opens the user's browser for login, listens for the callback,
+ * exchanges the code for a JWT access token.
+ *
+ * @param config OAuth2 configuration from the server spec
+ * @returns The access token (JWT) or undefined if cancelled
+ */
+export async function performOAuth2Login(config: IOAuth2Config): Promise<string | undefined> {
+	// Generate PKCE code verifier and challenge
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+	// Generate state for CSRF protection
+	const state = generateRandomHex(32);
+
+	// Discover endpoints from OpenID Configuration
+	const discoveryUrl = `${config.authority}/.well-known/openid-configuration`;
+	let authorizationEndpoint: string;
+	let tokenEndpoint: string;
+	try {
+		const discovery = await axios.get(discoveryUrl);
+		authorizationEndpoint = discovery.data.authorization_endpoint;
+		tokenEndpoint = discovery.data.token_endpoint;
+	} catch (err) {
+		vscode.window.showErrorMessage(`OAuth2: Failed to discover endpoints from ${discoveryUrl}`);
+		return undefined;
+	}
+
+	// Build the redirect URI using VS Code's URI handler
+	const callbackUri = vscode.Uri.parse(`${vscode.env.uriScheme}://intersystems-community.servermanager/oauth2-callback`);
+
+	// Build the authorization URL
+	// OpenID Connect scopes:
+	// - "openid": required by OIDC spec, triggers ID token issuance
+	// - "profile": includes user's name/picture in claims
+	// - "email": includes user's email in claims
+	const scopes = ["openid", "profile", "email"];
+	const authUrl = new URL(authorizationEndpoint);
+	authUrl.searchParams.set("client_id", config.clientId);
+	authUrl.searchParams.set("response_type", "code");
+	authUrl.searchParams.set("redirect_uri", callbackUri.toString());
+	authUrl.searchParams.set("scope", scopes.join(" "));
+	authUrl.searchParams.set("audience", config.audience);
+	authUrl.searchParams.set("state", state);
+	authUrl.searchParams.set("code_challenge", codeChallenge);
+	authUrl.searchParams.set("code_challenge_method", "S256");
+
+	// Set up a promise that resolves when the callback is received
+	const codePromise = new Promise<string | undefined>((resolve) => {
+		const disposable = vscode.window.registerUriHandler({
+			handleUri(uri: vscode.Uri): void {
+				const query = new URLSearchParams(uri.query);
+				const returnedState = query.get("state");
+				const code = query.get("code");
+				const error = query.get("error");
+
+				disposable.dispose();
+
+				if (error) {
+					vscode.window.showErrorMessage(`OAuth2 error: ${error} - ${query.get("error_description") || ""}`, { modal: true });
+					resolve(undefined);
+				} else if (returnedState !== state) {
+					vscode.window.showErrorMessage("OAuth2: State mismatch. Possible CSRF attack.", { modal: true });
+					resolve(undefined);
+				} else {
+					// Resolve immediately without showing a message
+					// The auth flow will continue seamlessly in the background
+					resolve(code || undefined);
+				}
+			},
+		});
+
+		// Auto-cancel after 2 minutes
+		setTimeout(() => {
+			disposable.dispose();
+			vscode.window.showWarningMessage("OAuth2: Login timed out. Please try again.", { modal: true });
+			resolve(undefined);
+		}, 120000);
+	});
+
+	// Open the browser for login silently
+	// User doesn't need to interact with VSCode - the browser will open and redirect back
+	await vscode.env.openExternal(vscode.Uri.parse(authUrl.toString()));
+
+	// Wait for the authorization code
+	const code = await codePromise;
+	if (!code) {
+		return undefined;
+	}
+
+	// Exchange the authorization code for an access token
+	try {
+		const tokenResponse = await axios.post(tokenEndpoint, new URLSearchParams({
+			grant_type: "authorization_code",
+			client_id: config.clientId,
+			code,
+			redirect_uri: callbackUri.toString(),
+			code_verifier: codeVerifier,
+		}).toString(), {
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		});
+
+		return tokenResponse.data.access_token;
+	} catch (err: any) {
+		const detail = err.response?.data?.error_description || err.message;
+		vscode.window.showErrorMessage(`OAuth2: Token exchange failed - ${detail}`);
+		return undefined;
+	}
+}
+
+function generateRandomHex(bytes: number): string {
+	const array = new Uint8Array(bytes);
+	globalThis.crypto.getRandomValues(array);
+	return Array.from(array, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function generateCodeVerifier(): string {
+	const array = new Uint8Array(32);
+	globalThis.crypto.getRandomValues(array);
+	return base64UrlEncode(array);
+}
+
+async function generateCodeChallenge(verifier: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const data = encoder.encode(verifier);
+	const hash = await globalThis.crypto.subtle.digest("SHA-256", data);
+	return base64UrlEncode(new Uint8Array(hash));
+}
+
+function base64UrlEncode(buffer: Uint8Array): string {
+	let binary = "";
+	for (const byte of buffer) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -44,7 +44,7 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 	// - "openid": required by OIDC spec, triggers ID token issuance
 	// - "profile": includes user's name/picture in claims
 	// - "email": includes user's email in claims
-	// It is standard to pass those scopes althought we don't need them
+	// It is standard to pass those scopes although we don't need them
 	const scopes = ["openid", "profile", "email"];
 	const authUrl = new URL(authorizationEndpoint);
 	authUrl.searchParams.set("client_id", config.clientId);

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import * as vscode from "vscode";
-import { log } from "./logger";
+import { logger } from "./logger";
 
 export interface IOAuth2Config {
 	authority: string;
@@ -25,7 +25,7 @@ async function discoverEndpoints(label: string, authority: string): Promise<{ au
 			tokenEndpoint: discovery.data.token_endpoint,
 		};
 	} catch (err: any) {
-		log(`OAuth2 [${label}]: discovery failed - ${err.message}`);
+		logger?.error(`OAuth2 [${label}]: discovery failed - ${err.message}`);
 		vscode.window.showErrorMessage(`OAuth2: Failed to discover endpoints from ${discoveryUrl}`, "Dismiss");
 		return undefined;
 	}
@@ -33,7 +33,7 @@ async function discoverEndpoints(label: string, authority: string): Promise<{ au
 
 function tokenSetFromResponse(label: string, data: any): IOAuth2TokenSet | undefined {
 	if (!data.access_token) { return undefined; }
-	log(`OAuth2 [${label}]: received token (expires_in=${data.expires_in ?? "n/a"}, refresh_token ${data.refresh_token ? "present" : "absent"})`);
+	logger?.debug(`OAuth2 [${label}]: received token (expires_in=${data.expires_in ?? "n/a"}, refresh_token ${data.refresh_token ? "present" : "absent"})`);
 	return {
 		accessToken: data.access_token,
 		refreshToken: data.refresh_token,
@@ -48,7 +48,7 @@ function tokenSetFromResponse(label: string, data: any): IOAuth2TokenSet | undef
  * listen for the callback, exchange the code for an access token (and refresh token if issued).
  */
 export async function performOAuth2Login(label: string, config: IOAuth2Config): Promise<IOAuth2TokenSet | undefined> {
-	log(`OAuth2 [${label}]: starting interactive login`);
+	logger?.info(`OAuth2 [${label}]: starting interactive login`);
 	const codeVerifier = generateCodeVerifier();
 	const codeChallenge = await generateCodeChallenge(codeVerifier);
 	const state = generateRandomHex(32); // CSRF protection
@@ -124,7 +124,7 @@ export async function performOAuth2Login(label: string, config: IOAuth2Config): 
 		return tokenSet;
 	} catch (err: any) {
 		const detail = err.response?.data?.error_description || err.message;
-		log(`OAuth2 [${label}]: token exchange failed - ${detail}`);
+		logger?.error(`OAuth2 [${label}]: token exchange failed - ${detail}`);
 		vscode.window.showErrorMessage(`OAuth2: Token exchange failed - ${detail}`, "Dismiss");
 		return undefined;
 	}
@@ -135,7 +135,7 @@ export async function performOAuth2Login(label: string, config: IOAuth2Config): 
  * @returns The new token set (carrying the rotated or existing refresh token), or undefined if the refresh token is invalid/expired.
  */
 export async function refreshOAuth2Token(label: string, config: IOAuth2Config, refreshToken: string): Promise<IOAuth2TokenSet | undefined> {
-	log(`OAuth2 [${label}]: refreshing access token`);
+	logger?.info(`OAuth2 [${label}]: refreshing access token`);
 	const endpoints = await discoverEndpoints(label, config.authority);
 	if (!endpoints) { return undefined; }
 	try {
@@ -152,7 +152,7 @@ export async function refreshOAuth2Token(label: string, config: IOAuth2Config, r
 		return tokenSet;
 	} catch (err: any) {
 		// Refresh token expired or revoked - caller falls back to interactive login
-		log(`OAuth2 [${label}]: refresh failed - ${err.response?.data?.error_description || err.message}`);
+		logger?.error(`OAuth2 [${label}]: refresh failed - ${err.response?.data?.error_description || err.message}`);
 		return undefined;
 	}
 }

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import * as vscode from "vscode";
+import { log } from "./logger";
 
 export interface IOAuth2Config {
 	authority: string;
@@ -7,45 +8,59 @@ export interface IOAuth2Config {
 	audience: string;
 }
 
-/**
- * Perform an OAuth2 Authorization Code + PKCE flow.
- * Opens the user's browser for login, listens for the callback,
- * exchanges the code for a JWT access token.
- *
- * @param config OAuth2 configuration from the server spec
- * @returns The access token (JWT) or undefined if cancelled
- */
-export async function performOAuth2Login(config: IOAuth2Config): Promise<string | undefined> {
-	// Generate PKCE code verifier and challenge
-	const codeVerifier = generateCodeVerifier();
-	const codeChallenge = await generateCodeChallenge(codeVerifier);
+export interface IOAuth2TokenSet {
+	accessToken: string;
+	/** Kept privately by Server Manager; never shared with consumers of the access token. */
+	refreshToken?: string;
+	/** Epoch milliseconds at which the access token should be treated as expired. */
+	expiresAt?: number;
+}
 
-	// Generate state for CSRF protection
-	const state = generateRandomHex(32);
-
-	// Discover endpoints from OpenID Configuration
-	const discoveryUrl = `${config.authority}/.well-known/openid-configuration`;
-	let authorizationEndpoint: string;
-	let tokenEndpoint: string;
+async function discoverEndpoints(label: string, authority: string): Promise<{ authorizationEndpoint: string; tokenEndpoint: string } | undefined> {
+	const discoveryUrl = `${authority}/.well-known/openid-configuration`;
 	try {
 		const discovery = await axios.get(discoveryUrl);
-		authorizationEndpoint = discovery.data.authorization_endpoint;
-		tokenEndpoint = discovery.data.token_endpoint;
-	} catch (err) {
+		return {
+			authorizationEndpoint: discovery.data.authorization_endpoint,
+			tokenEndpoint: discovery.data.token_endpoint,
+		};
+	} catch (err: any) {
+		log(`OAuth2 [${label}]: discovery failed - ${err.message}`);
 		vscode.window.showErrorMessage(`OAuth2: Failed to discover endpoints from ${discoveryUrl}`);
 		return undefined;
 	}
+}
 
-	// Build the redirect URI using VS Code's URI handler
+function tokenSetFromResponse(label: string, data: any): IOAuth2TokenSet | undefined {
+	if (!data.access_token) { return undefined; }
+	log(`OAuth2 [${label}]: received token (expires_in=${data.expires_in ?? "n/a"}, refresh_token ${data.refresh_token ? "present" : "absent"})`);
+	return {
+		accessToken: data.access_token,
+		refreshToken: data.refresh_token,
+		// Refresh early to avoid using a token that expires mid-request: 60s margin,
+		// but never more than 10% of a short-lived token's lifetime so we don't refresh constantly.
+		expiresAt: data.expires_in ? Date.now() + (data.expires_in - Math.min(60, data.expires_in * 0.1)) * 1000 : undefined,
+	};
+}
+
+/**
+ * Perform an OAuth2 Authorization Code + PKCE flow: open the browser for login,
+ * listen for the callback, exchange the code for an access token (and refresh token if issued).
+ */
+export async function performOAuth2Login(label: string, config: IOAuth2Config): Promise<IOAuth2TokenSet | undefined> {
+	log(`OAuth2 [${label}]: starting interactive login`);
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = await generateCodeChallenge(codeVerifier);
+	const state = generateRandomHex(32); // CSRF protection
+
+	const endpoints = await discoverEndpoints(label, config.authority);
+	if (!endpoints) { return undefined; }
+	const { authorizationEndpoint, tokenEndpoint } = endpoints;
+
 	const callbackUri = vscode.Uri.parse(`${vscode.env.uriScheme}://intersystems-community.servermanager/oauth2-callback`);
 
-	// Build the authorization URL
-	// OpenID Connect scopes:
-	// - "openid": required by OIDC spec, triggers ID token issuance
-	// - "profile": includes user's name/picture in claims
-	// - "email": includes user's email in claims
-	// It is standard to pass those scopes although we don't need them
-	const scopes = ["openid", "profile", "email"];
+	// "offline_access" requests a refresh token so we can renew silently
+	const scopes = ["openid", "profile", "email", "offline_access"];
 	const authUrl = new URL(authorizationEndpoint);
 	authUrl.searchParams.set("client_id", config.clientId);
 	authUrl.searchParams.set("response_type", "code");
@@ -56,7 +71,6 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 	authUrl.searchParams.set("code_challenge", codeChallenge);
 	authUrl.searchParams.set("code_challenge_method", "S256");
 
-	// Set up a promise that resolves when the callback is received
 	const codePromise = new Promise<string | undefined>((resolve) => {
 		const disposable = vscode.window.registerUriHandler({
 			handleUri(uri: vscode.Uri): void {
@@ -75,8 +89,6 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 					vscode.window.showErrorMessage("OAuth2: State mismatch. Possible CSRF attack.", { modal: true });
 					resolve(undefined);
 				} else {
-					// Resolve immediately without showing a message
-					// The auth flow will continue seamlessly in the background
 					resolve(code || undefined);
 				}
 			},
@@ -90,17 +102,11 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 		}, 120000);
 	});
 
-	// Open the browser for login silently
-	// User doesn't need to interact with VSCode - the browser will open and redirect back
 	await vscode.env.openExternal(vscode.Uri.parse(authUrl.toString()));
 
-	// Wait for the authorization code
 	const code = await codePromise;
-	if (!code) {
-		return undefined;
-	}
+	if (!code) { return undefined; }
 
-	// Exchange the authorization code for an access token
 	try {
 		const tokenResponse = await axios.post(tokenEndpoint, new URLSearchParams({
 			grant_type: "authorization_code",
@@ -111,14 +117,42 @@ export async function performOAuth2Login(config: IOAuth2Config): Promise<string 
 		}).toString(), {
 			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		});
-		if (!tokenResponse.data.access_token) {
+		const tokenSet = tokenSetFromResponse(label, tokenResponse.data);
+		if (!tokenSet) {
 			vscode.window.showErrorMessage("OAuth2: No access token in response");
-			return undefined;
 		}
-		return tokenResponse.data.access_token;
+		return tokenSet;
 	} catch (err: any) {
 		const detail = err.response?.data?.error_description || err.message;
+		log(`OAuth2 [${label}]: token exchange failed - ${detail}`);
 		vscode.window.showErrorMessage(`OAuth2: Token exchange failed - ${detail}`);
+		return undefined;
+	}
+}
+
+/**
+ * Renew an access token using a refresh token.
+ * @returns The new token set (carrying the rotated or existing refresh token), or undefined if the refresh token is invalid/expired.
+ */
+export async function refreshOAuth2Token(label: string, config: IOAuth2Config, refreshToken: string): Promise<IOAuth2TokenSet | undefined> {
+	log(`OAuth2 [${label}]: refreshing access token`);
+	const endpoints = await discoverEndpoints(label, config.authority);
+	if (!endpoints) { return undefined; }
+	try {
+		const tokenResponse = await axios.post(endpoints.tokenEndpoint, new URLSearchParams({
+			grant_type: "refresh_token",
+			client_id: config.clientId,
+			refresh_token: refreshToken,
+		}).toString(), {
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		});
+		const tokenSet = tokenSetFromResponse(label, tokenResponse.data);
+		// If the provider did not rotate the refresh token, keep the existing one
+		if (tokenSet && !tokenSet.refreshToken) { tokenSet.refreshToken = refreshToken; }
+		return tokenSet;
+	} catch (err: any) {
+		// Refresh token expired or revoked - caller falls back to interactive login
+		log(`OAuth2 [${label}]: refresh failed - ${err.response?.data?.error_description || err.message}`);
 		return undefined;
 	}
 }

--- a/src/oauth2Flow.ts
+++ b/src/oauth2Flow.ts
@@ -26,7 +26,7 @@ async function discoverEndpoints(label: string, authority: string): Promise<{ au
 		};
 	} catch (err: any) {
 		log(`OAuth2 [${label}]: discovery failed - ${err.message}`);
-		vscode.window.showErrorMessage(`OAuth2: Failed to discover endpoints from ${discoveryUrl}`);
+		vscode.window.showErrorMessage(`OAuth2: Failed to discover endpoints from ${discoveryUrl}`, "Dismiss");
 		return undefined;
 	}
 }
@@ -83,10 +83,10 @@ export async function performOAuth2Login(label: string, config: IOAuth2Config): 
 				clearTimeout(timeoutHandle);
 
 				if (error) {
-					vscode.window.showErrorMessage(`OAuth2 error: ${error} - ${query.get("error_description") || ""}`, { modal: true });
+					vscode.window.showErrorMessage(`OAuth2 error: ${error} - ${query.get("error_description") || ""}`, { modal: true }, "Dismiss");
 					resolve(undefined);
 				} else if (returnedState !== state) {
-					vscode.window.showErrorMessage("OAuth2: State mismatch. Possible CSRF attack.", { modal: true });
+					vscode.window.showErrorMessage("OAuth2: State mismatch. Possible CSRF attack.", { modal: true }, "Dismiss");
 					resolve(undefined);
 				} else {
 					resolve(code || undefined);
@@ -97,7 +97,7 @@ export async function performOAuth2Login(label: string, config: IOAuth2Config): 
 		// Auto-cancel after 2 minutes
 		const timeoutHandle = setTimeout(() => {
 			disposable.dispose();
-			vscode.window.showWarningMessage("OAuth2: Login timed out. Please try again.", { modal: true });
+			vscode.window.showWarningMessage("OAuth2: Login timed out. Please try again.", { modal: true }, "Dismiss");
 			resolve(undefined);
 		}, 120000);
 	});
@@ -119,13 +119,13 @@ export async function performOAuth2Login(label: string, config: IOAuth2Config): 
 		});
 		const tokenSet = tokenSetFromResponse(label, tokenResponse.data);
 		if (!tokenSet) {
-			vscode.window.showErrorMessage("OAuth2: No access token in response");
+			vscode.window.showErrorMessage("OAuth2: No access token in response", "Dismiss");
 		}
 		return tokenSet;
 	} catch (err: any) {
 		const detail = err.response?.data?.error_description || err.message;
 		log(`OAuth2 [${label}]: token exchange failed - ${detail}`);
-		vscode.window.showErrorMessage(`OAuth2: Token exchange failed - ${detail}`);
+		vscode.window.showErrorMessage(`OAuth2: Token exchange failed - ${detail}`, "Dismiss");
 		return undefined;
 	}
 }

--- a/src/oauth2Prompts.ts
+++ b/src/oauth2Prompts.ts
@@ -4,8 +4,8 @@ import * as vscode from "vscode";
  * Prompt the user to select an authentication method (password or oauth2).
  * Returns "password", "oauth2", or undefined if cancelled.
  */
-export async function promptAuthMethod(): Promise<string | undefined> {
-	return await new Promise<string | undefined>((resolve) => {
+export async function promptAuthMethod(): Promise<"password" | "oauth2" | undefined> {
+	return await new Promise((resolve) => {
 		const quickPick = vscode.window.createQuickPick();
 		quickPick.title = "Select the authentication method";
 		quickPick.ignoreFocusOut = true;
@@ -14,9 +14,9 @@ export async function promptAuthMethod(): Promise<string | undefined> {
 			{ label: "oauth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
 		];
 		quickPick.activeItems = [quickPick.items[0]];
-		let result: string | undefined;
+		let result: "password" | "oauth2";
 		quickPick.onDidChangeSelection((items) => {
-			result = items[0].label;
+			result = items[0].label as typeof result;
 		});
 		quickPick.onDidAccept(() => {
 			resolve(result);
@@ -62,20 +62,5 @@ export async function promptOAuth2ClientId(serverName: string): Promise<string |
 		title: `OAuth2 Configuration for '${serverName}'`,
 		prompt: "Enter the OAuth2 client ID for this application",
 		placeHolder: "your-client-id",
-	}) || undefined;
-}
-
-/**
- * Prompt the user for the OAuth2 audience.
- * Pre-fills with defaultAudience if provided.
- * Returns the entered value, or undefined if cancelled.
- */
-export async function promptOAuth2Audience(serverName: string, defaultAudience: string): Promise<string | undefined> {
-	return await vscode.window.showInputBox({
-		ignoreFocusOut: true,
-		title: `OAuth2 Configuration for '${serverName}'`,
-		prompt: "Enter the audience (API identifier registered with your IdP)",
-		placeHolder: defaultAudience || "https://your-iris-server/",
-		value: defaultAudience,
 	}) || undefined;
 }

--- a/src/oauth2Prompts.ts
+++ b/src/oauth2Prompts.ts
@@ -1,0 +1,81 @@
+import * as vscode from "vscode";
+
+/**
+ * Prompt the user to select an authentication method (password or oauth2).
+ * Returns "password", "oauth2", or undefined if cancelled.
+ */
+export async function promptAuthMethod(): Promise<string | undefined> {
+	return await new Promise<string | undefined>((resolve) => {
+		const quickPick = vscode.window.createQuickPick();
+		quickPick.title = "Select the authentication method";
+		quickPick.ignoreFocusOut = true;
+		quickPick.items = [
+			{ label: "password", description: "Classic username/password authentication" },
+			{ label: "oauth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
+		];
+		quickPick.activeItems = [quickPick.items[0]];
+		let result: string | undefined;
+		quickPick.onDidChangeSelection((items) => {
+			result = items[0].label;
+		});
+		quickPick.onDidAccept(() => {
+			resolve(result);
+			quickPick.hide();
+			quickPick.dispose();
+		});
+		quickPick.onDidHide(() => {
+			resolve(undefined);
+			quickPick.dispose();
+		});
+		quickPick.show();
+	});
+}
+
+/**
+ * Prompt the user for the OAuth2 authority URL.
+ * Returns the trimmed URL without trailing slash, or undefined if cancelled.
+ */
+export async function promptOAuth2Authority(serverName: string): Promise<string | undefined> {
+	const entered = await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: `OAuth2 Configuration for '${serverName}'`,
+		prompt: "Enter the OAuth2 authority URL (issuer)",
+		placeHolder: "https://your-identity-provider.com",
+		validateInput: (v) => {
+			if (!v.startsWith("https://") && !v.startsWith("http://")) {
+				return "Must be a URL starting with https:// or http://";
+			}
+			return undefined;
+		},
+	});
+	if (!entered) { return undefined; }
+	return entered.replace(/\/+$/, "");
+}
+
+/**
+ * Prompt the user for the OAuth2 client ID.
+ * Returns the entered value, or undefined if cancelled.
+ */
+export async function promptOAuth2ClientId(serverName: string): Promise<string | undefined> {
+	return await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: `OAuth2 Configuration for '${serverName}'`,
+		prompt: "Enter the OAuth2 client ID for this application",
+		placeHolder: "your-client-id",
+	}) || undefined;
+}
+
+/**
+ * Prompt the user for the OAuth2 audience.
+ * Pre-fills with defaultAudience if provided.
+ * Returns the entered value, or undefined if cancelled.
+ */
+export async function promptOAuth2Audience(serverName: string, defaultAudience: string): Promise<string | undefined> {
+	return await vscode.window.showInputBox({
+		ignoreFocusOut: true,
+		title: `OAuth2 Configuration for '${serverName}'`,
+		prompt: "Enter the audience (API identifier registered with your IdP)",
+		placeHolder: defaultAudience || "https://your-iris-server/",
+		value: defaultAudience,
+	}) || undefined;
+}

--- a/src/oauth2Prompts.ts
+++ b/src/oauth2Prompts.ts
@@ -14,7 +14,7 @@ export async function promptAuthMethod(): Promise<"password" | "oauth2" | undefi
 			{ label: "oauth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
 		];
 		quickPick.activeItems = [quickPick.items[0]];
-		let result: "password" | "oauth2";
+		let result: "password" | "oauth2" = "password";
 		quickPick.onDidChangeSelection((items) => {
 			result = items[0].label as typeof result;
 		});
@@ -62,5 +62,5 @@ export async function promptOAuth2ClientId(serverName: string): Promise<string |
 		title: `OAuth2 Configuration for '${serverName}'`,
 		prompt: "Enter the OAuth2 client ID for this application",
 		placeHolder: "your-client-id",
-	}) || undefined;
+	});
 }

--- a/src/oauth2Prompts.ts
+++ b/src/oauth2Prompts.ts
@@ -1,33 +1,5 @@
 import * as vscode from "vscode";
 
-/** Prompt for the authentication method, or undefined if cancelled. */
-export async function promptAuthMethod(): Promise<"password" | "oauth2" | undefined> {
-	return await new Promise((resolve) => {
-		const quickPick = vscode.window.createQuickPick();
-		quickPick.title = "Select the authentication method";
-		quickPick.ignoreFocusOut = true;
-		quickPick.items = [
-			{ label: "password", description: "Classic username/password authentication" },
-			{ label: "oauth2", description: "OAuth2/OpenID Connect (e.g., Auth0, Keycloak)" },
-		];
-		quickPick.activeItems = [quickPick.items[0]];
-		let result: "password" | "oauth2" = "password";
-		quickPick.onDidChangeSelection((items) => {
-			result = items[0].label as typeof result;
-		});
-		quickPick.onDidAccept(() => {
-			resolve(result);
-			quickPick.hide();
-			quickPick.dispose();
-		});
-		quickPick.onDidHide(() => {
-			resolve(undefined);
-			quickPick.dispose();
-		});
-		quickPick.show();
-	});
-}
-
 /** Prompt for the OAuth2 authority URL, trimmed of any trailing slash. */
 export async function promptOAuth2Authority(serverName: string): Promise<string | undefined> {
 	const entered = await vscode.window.showInputBox({

--- a/src/oauth2Prompts.ts
+++ b/src/oauth2Prompts.ts
@@ -34,7 +34,6 @@ export async function promptOAuth2Authority(serverName: string): Promise<string 
 		ignoreFocusOut: true,
 		title: `OAuth2 Configuration for '${serverName}'`,
 		prompt: "Enter the OAuth2 authority URL (issuer)",
-		placeHolder: "https://your-identity-provider.com",
 		validateInput: (v) => {
 			if (!v.startsWith("https://") && !v.startsWith("http://")) {
 				return "Must be a URL starting with https:// or http://";
@@ -52,6 +51,5 @@ export async function promptOAuth2ClientId(serverName: string): Promise<string |
 		ignoreFocusOut: true,
 		title: `OAuth2 Configuration for '${serverName}'`,
 		prompt: "Enter the OAuth2 client ID for this application",
-		placeHolder: "your-client-id",
 	});
 }

--- a/src/oauth2Prompts.ts
+++ b/src/oauth2Prompts.ts
@@ -1,9 +1,6 @@
 import * as vscode from "vscode";
 
-/**
- * Prompt the user to select an authentication method (password or oauth2).
- * Returns "password", "oauth2", or undefined if cancelled.
- */
+/** Prompt for the authentication method, or undefined if cancelled. */
 export async function promptAuthMethod(): Promise<"password" | "oauth2" | undefined> {
 	return await new Promise((resolve) => {
 		const quickPick = vscode.window.createQuickPick();
@@ -31,10 +28,7 @@ export async function promptAuthMethod(): Promise<"password" | "oauth2" | undefi
 	});
 }
 
-/**
- * Prompt the user for the OAuth2 authority URL.
- * Returns the trimmed URL without trailing slash, or undefined if cancelled.
- */
+/** Prompt for the OAuth2 authority URL, trimmed of any trailing slash. */
 export async function promptOAuth2Authority(serverName: string): Promise<string | undefined> {
 	const entered = await vscode.window.showInputBox({
 		ignoreFocusOut: true,
@@ -52,10 +46,7 @@ export async function promptOAuth2Authority(serverName: string): Promise<string 
 	return entered.replace(/\/+$/, "");
 }
 
-/**
- * Prompt the user for the OAuth2 client ID.
- * Returns the entered value, or undefined if cancelled.
- */
+/** Prompt for the OAuth2 client ID. */
 export async function promptOAuth2ClientId(serverName: string): Promise<string | undefined> {
 	return await vscode.window.showInputBox({
 		ignoreFocusOut: true,

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -1,0 +1,10 @@
+import { GeneralIServerSpec as GeneralIServerSetting, PasswordAuthorization } from "@intersystems-community/intersystems-servermanager";
+
+export interface OAuth2Config {
+	authority: string;
+	clientId: string;
+}
+
+export type PasswordIServerSetting = GeneralIServerSetting & PasswordAuthorization;
+export type OAuth2IServerSetting = GeneralIServerSetting & { oauth2: OAuth2Config };
+export type IServerSetting = PasswordIServerSetting | OAuth2IServerSetting;

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -6,7 +6,8 @@ export interface OAuth2Config {
 }
 
 export interface IServerSetting extends Omit<IServerSpec, "auth"> {
-	username?: string;
 	password?: string;
 	oauth2?: OAuth2Config
 };
+
+export type AuthRelatedSetting = Pick<IServerSetting, "username" | "password" | "oauth2">;

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -1,10 +1,12 @@
-import { GeneralIServerSpec as GeneralIServerSetting, PasswordAuthorization } from "@intersystems-community/intersystems-servermanager";
+import { IServerSpec } from "@intersystems-community/intersystems-servermanager";
 
 export interface OAuth2Config {
 	authority: string;
 	clientId: string;
 }
 
-export type PasswordIServerSetting = GeneralIServerSetting & PasswordAuthorization;
-export type OAuth2IServerSetting = GeneralIServerSetting & { oauth2: OAuth2Config };
-export type IServerSetting = PasswordIServerSetting | OAuth2IServerSetting;
+export interface IServerSetting extends Omit<IServerSpec, "authorization"> {
+	username?: string;
+	password?: string;
+	oauth2?: OAuth2Config
+};

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -5,7 +5,7 @@ export interface OAuth2Config {
 	clientId: string;
 }
 
-export interface IServerSetting extends Omit<IServerSpec, "authorization"> {
+export interface IServerSetting extends Omit<IServerSpec, "auth"> {
 	username?: string;
 	password?: string;
 	oauth2?: OAuth2Config

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -6,7 +6,6 @@ export interface OAuth2Config {
 }
 
 export interface IServerSetting extends Omit<IServerSpec, "auth"> {
-	password?: string;
 	oauth2?: OAuth2Config
 };
 

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -9,5 +9,5 @@ export interface IServerSetting extends Omit<IServerSpec, "auth" | "username" | 
 	// username and password are deprecated in IServerSpec but not in IServerSetting
 	username?: string;
 	password?: string;
-	oauth2?: OAuth2Config
-};
+	oauth2?: OAuth2Config;
+}

--- a/src/serverSetting.ts
+++ b/src/serverSetting.ts
@@ -5,8 +5,9 @@ export interface OAuth2Config {
 	clientId: string;
 }
 
-export interface IServerSetting extends Omit<IServerSpec, "auth"> {
+export interface IServerSetting extends Omit<IServerSpec, "auth" | "username" | "password"> {
+	// username and password are deprecated in IServerSpec but not in IServerSetting
+	username?: string;
+	password?: string;
 	oauth2?: OAuth2Config
 };
-
-export type AuthRelatedSetting = Pick<IServerSetting, "username" | "password" | "oauth2">;

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -441,20 +441,17 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 
 async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpec | undefined> {
 	const { name, description, detail, scope } = serverSummary;
+	const spec = await getServerSpec(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
-		// Get full server spec first to preserve authMethod, oauth2, etc.
-		const serverSpec = await getServerSpec(name, scope);
-		if (serverSpec) {
-			// Override with Docker-specific connection details
-			serverSpec.webServer.host = "127.0.0.1";
-			serverSpec.webServer.port = parseInt(dockerDetail[1], 10);
-			return serverSpec;
+		if (!spec) {
+			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" } } as IServerSpec;
 		}
-		// Fallback for servers without a spec in settings
-		return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" } } as IServerSpec;
+		// Override with Docker-specific connection details
+		spec.webServer.host = "127.0.0.1";
+		spec.webServer.port = parseInt(dockerDetail[1], 10);
 	}
-	return getServerSpec(name, scope);
+	return spec;
 }
 
 // tslint:disable-next-line: max-classes-per-file

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -450,11 +450,18 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 
 async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpec | undefined> {
 	const { name, description, detail, scope } = serverSummary;
+	let spec = await getServerSpec(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
-		return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") };
+		if (spec === undefined) {
+			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") }
+		} else {
+			spec.webServer = {
+				scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: ""
+			}
+		}
 	}
-	return await getServerSpec(name, scope);
+	return spec;
 }
 
 // tslint:disable-next-line: max-classes-per-file

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -523,7 +523,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 		try {
 			const response = await makeRESTRequest("GET", serverSpec);
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec["username"] || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', `${response.status} ${response.statusText}`));
 			} else {
 				const serverApiVersion = response.data.result.content.api;
 				response.data.result.content.namespaces.map((namespace: string) => {
@@ -531,7 +531,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 				});
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec["username"] || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', errorStr as string));
 		}
 	}
 

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
-import { getServerSpec } from "../api/getServerSpec";
+import { getServerSetting } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
 import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { makeRESTRequest } from "../makeRESTRequest";
@@ -428,12 +428,12 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 				response = await makeRESTRequest("HEAD", serverSpec);
 			}
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', `${response.status} ${response.statusText}`));
 			} else {
-				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec.username || 'UnknownUser'));
+				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec['username'] || 'UnknownUser'));
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', errorStr as string));
 		}
 	}
 	return children;
@@ -441,7 +441,7 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 
 async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpec | undefined> {
 	const { name, description, detail, scope } = serverSummary;
-	const spec = await getServerSpec(name, scope);
+	const spec = await getServerSetting(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
 		if (!spec) {
@@ -523,7 +523,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 		try {
 			const response = await makeRESTRequest("GET", serverSpec);
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', `${response.status} ${response.statusText}`));
 			} else {
 				const serverApiVersion = response.data.result.content.api;
 				response.data.result.content.namespaces.map((namespace: string) => {
@@ -531,7 +531,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 				});
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', errorStr as string));
 		}
 	}
 
@@ -633,7 +633,7 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: any): Promi
 			if (response.data.result.content === undefined) {
 				let message;
 				if (response.data.status?.errors[0]?.code === 5540) {
-					message = `To allow user '${serverSpec.username}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${serverSpec.username}"`;
+					message = `To allow user '${serverSpec['username'] || 'UnknownUser'}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${serverSpec['username'] || 'UnknownUser'}"`;
 				} else {
 					message = response.data.status.summary;
 				}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -450,17 +450,11 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 
 async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpec | undefined> {
 	const { name, description, detail, scope } = serverSummary;
-	const spec = await getServerSpec(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
-		if (!spec) {
-			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") };
-		}
-		// Override with Docker-specific connection details
-		spec.webServer.host = "127.0.0.1";
-		spec.webServer.port = parseInt(dockerDetail[1], 10);
+		return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") };
 	}
-	return spec;
+	return await getServerSpec(name, scope);
 }
 
 // tslint:disable-next-line: max-classes-per-file

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -454,7 +454,7 @@ async function specFromServerSummary(serverSummary: IServerName): Promise<IServe
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
 		if (!spec) {
-			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: PasswordAuthorization.new("", "") };
+			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") };
 		}
 		// Override with Docker-specific connection details
 		spec.webServer.host = "127.0.0.1";

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
-import { getServerSetting } from "../api/getServerSpec";
+import { getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
 import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { makeRESTRequest } from "../makeRESTRequest";
@@ -441,7 +441,7 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 
 async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpec | undefined> {
 	const { name, description, detail, scope } = serverSummary;
-	const spec = await getServerSetting(name, scope);
+	const spec = await getServerSpec(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
 		if (!spec) {

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -424,7 +424,7 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 			let response = await makeRESTRequest("HEAD", serverSpec);
 			if (response?.status === 401) {
 				// Authentication error, so retry in case first attempt cleared a no-longer-valid stored password
-				serverSpec.password = undefined;
+				serverSpec["password"] = undefined;
 				response = await makeRESTRequest("HEAD", serverSpec);
 			}
 			if (response?.status !== 200) {
@@ -433,7 +433,7 @@ async function serverFeatures(element: ServerTreeItem, params?: any): Promise<Fe
 				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec.username || 'UnknownUser'));
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', errorStr));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', errorStr as string));
 		}
 	}
 	return children;
@@ -443,7 +443,16 @@ async function specFromServerSummary(serverSummary: IServerName): Promise<IServe
 	const { name, description, detail, scope } = serverSummary;
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
-		return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" } };
+		// Get full server spec first to preserve authMethod, oauth2, etc.
+		const serverSpec = await getServerSpec(name, scope);
+		if (serverSpec) {
+			// Override with Docker-specific connection details
+			serverSpec.webServer.host = "127.0.0.1";
+			serverSpec.webServer.port = parseInt(dockerDetail[1], 10);
+			return serverSpec;
+		}
+		// Fallback for servers without a spec in settings
+		return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" } } as IServerSpec;
 	}
 	return getServerSpec(name, scope);
 }
@@ -517,7 +526,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 		try {
 			const response = await makeRESTRequest("GET", serverSpec);
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec["username"] || 'UnknownUser', `${response.status} ${response.statusText}`));
 			} else {
 				const serverApiVersion = response.data.result.content.api;
 				response.data.result.content.namespaces.map((namespace: string) => {
@@ -525,7 +534,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<
 				});
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.username || 'UnknownUser', errorStr));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec["username"] || 'UnknownUser', errorStr as string));
 		}
 	}
 

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -437,12 +437,12 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 				response = await makeRESTRequest("HEAD", serverSpec);
 			}
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', `${response.status} ${response.statusText}`));
 			} else {
-				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec['username'] || 'UnknownUser'));
+				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec.auth.username || 'UnknownUser'));
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', errorStr as string));
 		}
 	}
 	return children;
@@ -532,7 +532,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: ServerParams):
 		try {
 			const response = await makeRESTRequest("GET", serverSpec);
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', `${response.status} ${response.statusText}`));
 			} else {
 				const serverApiVersion = response.data.result.content.api;
 				response.data.result.content.namespaces.map((namespace: string) => {
@@ -540,7 +540,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: ServerParams):
 				});
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec['username'] || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', errorStr as string));
 		}
 	}
 
@@ -642,7 +642,7 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: ServerParam
 			if (response.data.result.content === undefined) {
 				let message;
 				if (response.data.status?.errors[0]?.code === 5540) {
-					message = `To allow user '${serverSpec['username'] || 'UnknownUser'}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${serverSpec['username'] || 'UnknownUser'}"`;
+					message = `To allow user '${serverSpec.auth.username || 'UnknownUser'}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${serverSpec.auth.username || 'UnknownUser'}"`;
 				} else {
 					message = response.data.status.summary;
 				}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -433,7 +433,6 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 			let response = await makeRESTRequest("HEAD", serverSpec);
 			if (response?.status === 401) {
 				// Authentication error, so retry in case first attempt cleared a no-longer-valid stored password
-				serverSpec["password"] = undefined;
 				serverSpec.auth.clear() as void;
 				response = await makeRESTRequest("HEAD", serverSpec);
 			}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -434,6 +434,7 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 			if (response?.status === 401) {
 				// Authentication error, so retry in case first attempt cleared a no-longer-valid stored password
 				serverSpec["password"] = undefined;
+				serverSpec.auth.clear() as void;
 				response = await makeRESTRequest("HEAD", serverSpec);
 			}
 			if (response?.status !== 200) {

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -4,7 +4,7 @@ import { getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
 import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
 import { makeRESTRequest } from "../makeRESTRequest";
-import { OBJECTSCRIPT_EXTENSIONID } from "../commonActivate";
+import { OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
 const SETTINGS_VERSION = "v1";
 
@@ -454,7 +454,7 @@ async function specFromServerSummary(serverSummary: IServerName): Promise<IServe
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
 		if (!spec) {
-			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" } } as IServerSpec;
+			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: PasswordAuthorization.new("", "") };
 		}
 		// Override with Docker-specific connection details
 		spec.webServer.host = "127.0.0.1";

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
 import { getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
-import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerName, IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
 import { makeRESTRequest } from "../makeRESTRequest";
 import { OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
 
@@ -215,7 +215,7 @@ export interface ServerParams {
 	sorted?: boolean;
 	serverSummary?: IServerName;
 	serverName?: string;
-	serverSpec?: IServerSpec;
+	serverSpec?: IServerSpecWithAuth;
 	serverApiVersion?: number;
 	ns?: string;
 }
@@ -448,7 +448,7 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 	return children;
 }
 
-async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpec | undefined> {
+async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpecWithAuth | undefined> {
 	const { name, description, detail, scope } = serverSummary;
 	let spec = await getServerSpec(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
@@ -495,7 +495,7 @@ export class NamespacesTreeItem extends FeatureTreeItem {
 	constructor(
 		element: ISMItem,
 		serverName: string,
-		serverSpec: IServerSpec,
+		serverSpec: IServerSpecWithAuth,
 		username: string
 	) {
 		const parentFolderId = element.parent?.id || "";
@@ -525,7 +525,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: ServerParams):
 
 	if (params?.serverName) {
 		const name: string = params.serverName;
-		const serverSpec: IServerSpec | undefined = params.serverSpec;
+		const serverSpec = params.serverSpec;
 		if (!serverSpec) {
 			return undefined;
 		}
@@ -560,7 +560,7 @@ export class NamespaceTreeItem extends SMTreeItem {
 		element: ISMItem,
 		name: string,
 		serverName: string,
-		serverSpec: IServerSpec,
+		serverSpec: IServerSpecWithAuth,
 		serverApiVersion: number
 	) {
 		const parentFolderId = element.parent?.id || "";
@@ -598,7 +598,7 @@ export class ProjectsTreeItem extends FeatureTreeItem {
 	constructor(
 		element: ISMItem,
 		serverName?: string,
-		serverSpec?: IServerSpec,
+		serverSpec?: IServerSpecWithAuth,
 		serverApiVersion: number = 0
 	) {
 		const parentFolderId = element.parent?.id || '';
@@ -628,7 +628,7 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: ServerParam
 
 	if (params?.serverName && params.ns) {
 		const name: string = params.serverName;
-		const serverSpec: IServerSpec | undefined = params.serverSpec;
+		const serverSpec = params.serverSpec;
 		if (!serverSpec) {
 			return undefined
 		}
@@ -687,7 +687,7 @@ export class WebAppsTreeItem extends FeatureTreeItem {
 	constructor(
 		element: ISMItem,
 		serverName: string | undefined,
-		serverSpec: IServerSpec | undefined,
+		serverSpec: IServerSpecWithAuth | undefined,
 		serverApiVersion: number = 0
 	) {
 		const parentFolderId = element.parent?.id || '';
@@ -717,7 +717,7 @@ async function namespaceWebApps(element: ProjectsTreeItem, params?: ServerParams
 
 	if (params?.serverName && params.ns) {
 		const name: string = params.serverName;
-		const serverSpec: IServerSpec | undefined = params.serverSpec;
+		const serverSpec = params.serverSpec;
 		if (!serverSpec) {
 			return undefined
 		}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -643,7 +643,8 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: ServerParam
 			if (response.data.result.content === undefined) {
 				let message;
 				if (response.data.status?.errors[0]?.code === 5540) {
-					message = `To allow user '${serverSpec.auth.username || 'UnknownUser'}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${serverSpec.auth.username || 'UnknownUser'}"`;
+					const username = serverSpec.auth.username || 'UnknownUser';
+					message = `To allow user '${username}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${username}"`;
 				} else {
 					message = response.data.status.summary;
 				}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
 import { getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
-import { OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
+import { OBJECTSCRIPT_EXTENSIONID, BasicAuthorization } from "../commonActivate";
 import { makeRESTRequest } from "../makeRESTRequest";
 
 const SETTINGS_VERSION = "v1";
@@ -454,7 +454,7 @@ async function specFromServerSummary(serverSummary: IServerName): Promise<IServe
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
 		if (spec === undefined) {
-			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") };
+			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new BasicAuthorization() };
 		} else {
 			spec.webServer = {
 				scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "",

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -1,10 +1,10 @@
+import { IServerName, IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
 import * as vscode from "vscode";
 import { getServerNames } from "../api/getServerNames";
 import { getServerSpec } from "../api/getServerSpec";
 import { getServerSummary } from "../api/getServerSummary";
-import { IServerName, IServerSpecWithAuth } from "@intersystems-community/intersystems-servermanager";
-import { makeRESTRequest } from "../makeRESTRequest";
 import { OBJECTSCRIPT_EXTENSIONID, PasswordAuthorization } from "../commonActivate";
+import { makeRESTRequest } from "../makeRESTRequest";
 
 const SETTINGS_VERSION = "v1";
 
@@ -237,9 +237,9 @@ interface ISMItem {
 export class SMTreeItem extends vscode.TreeItem {
 
 	public readonly parent: SMTreeItem | undefined;
+	public readonly params?: ServerParams;
 	// tslint:disable-next-line: ban-types
 	private readonly _getChildren?: Function;
-	public readonly params?: ServerParams;
 
 	constructor(item: ISMItem) {
 		const collapsibleState = item.getChildren
@@ -280,12 +280,12 @@ function allServers(treeItem: SMTreeItem, params?: ServerParams): ServerTreeItem
 	}));
 	// Add children for servers defined at the workspace folder level
 	vscode.workspace.workspaceFolders?.map((wf) => {
-		if (["isfs", "isfs-readonly"].includes(wf.uri.scheme)) return;
+		if (["isfs", "isfs-readonly"].includes(wf.uri.scheme)) { return; }
 		children.push(...getServerNames(wf).filter((wfs) => !wsServerNames.some((wss) => wss.name == wfs.name)).map((wfs) => {
 			return new ServerTreeItem({ label: `${wfs.name} (${wf.name})`, id: wfs.name, parent: treeItem }, wfs);
 		}));
 	});
-	if (params?.sorted) children.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+	if (params?.sorted) { children.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0); }
 	return children;
 }
 
@@ -346,7 +346,7 @@ async function currentServers(element: SMTreeItem, params?: ServerParams): Promi
 				new ServerTreeItem({ parent: element, label: `docker:${port}`, id: name }, serverSummary),
 			);
 		}
-	})
+	});
 
 	return Array.from(children.values()).sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
 }
@@ -423,7 +423,7 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 	const children: FeatureTreeItem[] = [];
 
 	if (params?.serverSummary) {
-		let serverSpec = await specFromServerSummary(params.serverSummary);
+		const serverSpec = await specFromServerSummary(params.serverSummary);
 		if (!serverSpec) {
 			return undefined;
 		}
@@ -437,12 +437,12 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 				response = await makeRESTRequest("HEAD", serverSpec);
 			}
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || "UnknownUser", `${response.status} ${response.statusText}`));
 			} else {
-				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec.auth.username || 'UnknownUser'));
+				children.push(new NamespacesTreeItem({ parent: element, label: name, id: name }, element.name, serverSpec, serverSpec.auth.username || "UnknownUser"));
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || "UnknownUser", errorStr as string));
 		}
 	}
 	return children;
@@ -450,15 +450,15 @@ async function serverFeatures(element: ServerTreeItem, params?: ServerParams): P
 
 async function specFromServerSummary(serverSummary: IServerName): Promise<IServerSpecWithAuth | undefined> {
 	const { name, description, detail, scope } = serverSummary;
-	let spec = await getServerSpec(name, scope);
+	const spec = await getServerSpec(name, scope);
 	const dockerDetail = detail.match(/^http:\/\/localhost:(\d+)\/$/);
 	if (dockerDetail) {
 		if (spec === undefined) {
-			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") }
+			return { name, description, webServer: { scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "" }, auth: new PasswordAuthorization("", "") };
 		} else {
 			spec.webServer = {
-				scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: ""
-			}
+				scheme: "http", host: "127.0.0.1", port: parseInt(dockerDetail[1], 10), pathPrefix: "",
+			};
 		}
 	}
 	return spec;
@@ -496,7 +496,7 @@ export class NamespacesTreeItem extends FeatureTreeItem {
 		element: ISMItem,
 		serverName: string,
 		serverSpec: IServerSpecWithAuth,
-		username: string
+		username: string,
 	) {
 		const parentFolderId = element.parent?.id || "";
 		super({
@@ -533,7 +533,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: ServerParams):
 		try {
 			const response = await makeRESTRequest("GET", serverSpec);
 			if (response?.status !== 200) {
-				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', `${response.status} ${response.statusText}`));
+				children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || "UnknownUser", `${response.status} ${response.statusText}`));
 			} else {
 				const serverApiVersion = response.data.result.content.api;
 				response.data.result.content.namespaces.map((namespace: string) => {
@@ -541,7 +541,7 @@ async function serverNamespaces(element: ServerTreeItem, params?: ServerParams):
 				});
 			}
 		} catch (errorStr) {
-			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || 'UnknownUser', errorStr as string));
+			children.push(new OfflineTreeItem({ parent: element, label: name, id: name }, serverSpec.auth.username || "UnknownUser", errorStr as string));
 		}
 	}
 
@@ -561,7 +561,7 @@ export class NamespaceTreeItem extends SMTreeItem {
 		name: string,
 		serverName: string,
 		serverSpec: IServerSpecWithAuth,
-		serverApiVersion: number
+		serverApiVersion: number,
 	) {
 		const parentFolderId = element.parent?.id || "";
 		const id = parentFolderId + ":" + name;
@@ -571,7 +571,7 @@ export class NamespaceTreeItem extends SMTreeItem {
 			parent: element.parent,
 			tooltip: `${name} on ${serverName}`,
 			getChildren: namespaceFeatures,
-			params: { serverName, serverSpec, serverApiVersion }
+			params: { serverName, serverSpec, serverApiVersion },
 		});
 		this.name = name;
 		this.contextValue = `${serverApiVersion.toString()}${serverItemIsWsFolder(element?.parent?.parent) ? "/wsFolder" : ""}/${name === "%SYS" ? "sysnamespace" : "namespace"}`;
@@ -589,7 +589,7 @@ export class NamespaceTreeItem extends SMTreeItem {
 async function namespaceFeatures(element: NamespaceTreeItem, params?: ServerParams): Promise<FeatureTreeItem[] | undefined> {
 	return [
 		new ProjectsTreeItem({ parent: element, id: element.name, label: element.name }, params?.serverName, params?.serverSpec, params?.serverApiVersion),
-		new WebAppsTreeItem({ parent: element, id: element.name, label: element.name }, params?.serverName, params?.serverSpec, params?.serverApiVersion)
+		new WebAppsTreeItem({ parent: element, id: element.name, label: element.name }, params?.serverName, params?.serverSpec, params?.serverApiVersion),
 	];
 }
 
@@ -599,20 +599,20 @@ export class ProjectsTreeItem extends FeatureTreeItem {
 		element: ISMItem,
 		serverName?: string,
 		serverSpec?: IServerSpecWithAuth,
-		serverApiVersion: number = 0
+		serverApiVersion: number = 0,
 	) {
-		const parentFolderId = element.parent?.id || '';
+		const parentFolderId = element.parent?.id || "";
 		super({
 			parent: element.parent,
-			label: 'Projects',
-			id: parentFolderId + ':projects',
+			label: "Projects",
+			id: parentFolderId + ":projects",
 			tooltip: `Projects in this namespace`,
 			getChildren: namespaceProjects,
-			params: { serverName, serverSpec, serverApiVersion, ns: element.label }
+			params: { serverName, serverSpec, serverApiVersion, ns: element.label },
 		});
-		this.name = 'Projects';
-		this.contextValue = serverApiVersion.toString() + '/projects';
-		this.iconPath = new vscode.ThemeIcon('library');
+		this.name = "Projects";
+		this.contextValue = serverApiVersion.toString() + "/projects";
+		this.iconPath = new vscode.ThemeIcon("library");
 	}
 }
 
@@ -630,20 +630,20 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: ServerParam
 		const name: string = params.serverName;
 		const serverSpec = params.serverSpec;
 		if (!serverSpec) {
-			return undefined
+			return undefined;
 		}
 
 		const response = await makeRESTRequest(
 			"POST",
 			serverSpec,
 			{ apiVersion: 1, namespace: params.ns, path: "/action/query" },
-			{ query: "SELECT Name, Description FROM %Studio.Project", parameters: [] }
+			{ query: "SELECT Name, Description FROM %Studio.Project", parameters: [] },
 		);
 		if (response?.status === 200) {
 			if (response.data.result.content === undefined) {
 				let message;
 				if (response.data.status?.errors[0]?.code === 5540) {
-					const username = serverSpec.auth.username || 'UnknownUser';
+					const username = serverSpec.auth.username || "UnknownUser";
 					message = `To allow user '${username}' to list projects in namespace '${params.ns}', run this SQL statement there using an account with sufficient privilege: GRANT SELECT ON %Studio.Project TO "${username}"`;
 				} else {
 					message = response.data.status.summary;
@@ -666,19 +666,19 @@ export class ProjectTreeItem extends SMTreeItem {
 		element: ISMItem,
 		name: string,
 		description: string,
-		serverApiVersion: number
+		serverApiVersion: number,
 	) {
-		const parentFolderId = element.parent?.id || '';
-		const id = parentFolderId + ':' + name;
+		const parentFolderId = element.parent?.id || "";
+		const id = parentFolderId + ":" + name;
 		super({
 			parent: element.parent,
 			label: name,
 			id,
-			tooltip: description
+			tooltip: description,
 		});
 		this.name = name;
 		this.contextValue = `${serverApiVersion.toString()}${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "/wsFolder" : ""}/project`;
-		this.iconPath = new vscode.ThemeIcon('files');
+		this.iconPath = new vscode.ThemeIcon("files");
 	}
 }
 
@@ -688,20 +688,20 @@ export class WebAppsTreeItem extends FeatureTreeItem {
 		element: ISMItem,
 		serverName: string | undefined,
 		serverSpec: IServerSpecWithAuth | undefined,
-		serverApiVersion: number = 0
+		serverApiVersion: number = 0,
 	) {
-		const parentFolderId = element.parent?.id || '';
+		const parentFolderId = element.parent?.id || "";
 		super({
 			parent: element.parent,
-			label: 'Web Applications',
-			id: parentFolderId + ':webapps',
+			label: "Web Applications",
+			id: parentFolderId + ":webapps",
 			tooltip: `Web Applications in this namespace`,
 			getChildren: namespaceWebApps,
-			params: { serverName, serverSpec, serverApiVersion, ns: element.label }
+			params: { serverName, serverSpec, serverApiVersion, ns: element.label },
 		});
-		this.name = 'Web Applications';
-		this.contextValue = serverApiVersion.toString() + '/webapps';
-		this.iconPath = new vscode.ThemeIcon('globe');
+		this.name = "Web Applications";
+		this.contextValue = serverApiVersion.toString() + "/webapps";
+		this.iconPath = new vscode.ThemeIcon("globe");
 	}
 }
 
@@ -719,13 +719,13 @@ async function namespaceWebApps(element: ProjectsTreeItem, params?: ServerParams
 		const name: string = params.serverName;
 		const serverSpec = params.serverSpec;
 		if (!serverSpec) {
-			return undefined
+			return undefined;
 		}
 
 		const response = await makeRESTRequest(
 			"GET",
 			serverSpec,
-			{ apiVersion: 1, namespace: "%SYS", path: `/cspapps/${params.ns}?detail=1` }
+			{ apiVersion: 1, namespace: "%SYS", path: `/cspapps/${params.ns}?detail=1` },
 		);
 		if (response?.status === 200) {
 			if (response.data.result.content === undefined) {
@@ -744,15 +744,15 @@ async function namespaceWebApps(element: ProjectsTreeItem, params?: ServerParams
 export class WebAppTreeItem extends SMTreeItem {
 	public readonly name: string;
 	constructor(element: ISMItem, name: string, isDefault: boolean, serverApiVersion: number) {
-		const parentFolderId = element.parent?.id || '';
-		const id = parentFolderId + ':' + name;
+		const parentFolderId = element.parent?.id || "";
+		const id = parentFolderId + ":" + name;
 		super({
 			parent: element.parent,
 			label: name,
-			id
+			id,
 		});
 		this.name = name;
 		this.contextValue = `${serverApiVersion.toString()}${serverItemIsWsFolder(element?.parent?.parent?.parent?.parent) ? "/wsFolder" : ""}/webapp`;
-		this.iconPath = new vscode.ThemeIcon(isDefault ? 'folder-active' : 'folder');
+		this.iconPath = new vscode.ThemeIcon(isDefault ? "folder-active" : "folder");
 	}
 }

--- a/src/web-extension.ts
+++ b/src/web-extension.ts
@@ -1,9 +1,9 @@
 "use strict";
 
 import * as vscode from "vscode";
-import { ServerManagerView } from "./ui/serverManagerView";
 import { commonActivate } from "./commonActivate";
 import { logout, serverSessions } from "./makeRESTRequest";
+import { ServerManagerView } from "./ui/serverManagerView";
 
 export function activate(context: vscode.ExtensionContext) {
 	const view = new ServerManagerView(context);
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
 	// Do our best to log out of all sessions
 
-	const promises: Promise<void>[] = [];
+	const promises: Array<Promise<void>> = [];
 	for (const serverSession of serverSessions) {
 		promises.push(logout(serverSession[1].serverName));
 	}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,13 +22,6 @@ export interface ISuperServerSpec {
 	port: number;
 }
 
-export interface GeneralIServerSpec {
-	name: string;
-	webServer: IWebServerSpec;
-	superServer?: ISuperServerSpec;
-	description?: string;
-}
-
 export interface PasswordAuthorization {
 	authMethod?: "password";
 	username?: string;
@@ -48,9 +41,22 @@ export interface OAuth2Authorization {
 
 export type Authorization = PasswordAuthorization | OAuth2Authorization;
 
+interface GeneralIJSONServerSpec {
+	webServer: IWebServerSpec;
+	superServer?: ISuperServerSpec;
+	description?: string;
+}
+
+export type PasswordIJSONServerSpec = GeneralIJSONServerSpec & PasswordAuthorization;
+export type OAuth2IJSONServerSpec = GeneralIJSONServerSpec & OAuth2Authorization;
+export type IJSONServerSpec = PasswordIJSONServerSpec | OAuth2IJSONServerSpec;
+
+interface GeneralIServerSpec extends GeneralIJSONServerSpec {
+	name: string;
+}
+
 export type PasswordIServerSpec = GeneralIServerSpec & PasswordAuthorization;
 export type OAuth2IServerSpec = GeneralIServerSpec & OAuth2Authorization;
-
 export type IServerSpec = PasswordIServerSpec | OAuth2IServerSpec;
 
 export interface ServerManagerAPI {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ export interface ServerManagerAPI {
 	): Promise<IServerSpec | undefined>;
 
 	getAccount(
-		serverSpec: IServerSpec
+		serverSpec: { name: string, username?: string }
 	): vscode.AuthenticationSessionAccountInformation | undefined;
 
 	onDidChangePassword(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,34 +22,16 @@ export interface ISuperServerSpec {
 	port: number;
 }
 
-export interface PasswordAuthorization {
-	// The properties are present only if defined in the settings JSON.
-	//   Storage of `password` there is deprecated and strongly discouraged.
-	username?: string;
-	password?: string;
-}
-
-export interface OAuth2Authorization {
-	// The bearer_token is never present by getServerSpec for now.
-	bearer_token: string | undefined;
-}
-
-export type Authorization = PasswordAuthorization | OAuth2Authorization;
-
-export interface GeneralIJSONServerSpec {
+export interface IJSONServerSpec {
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
 	description?: string;
+	authorization: Authorization;
 }
 
-export type IJSONServerSpec = GeneralIJSONServerSpec & Authorization;
-
-export interface GeneralIServerSpec extends GeneralIJSONServerSpec {
+export interface IServerSpec extends IJSONServerSpec {
 	name: string;
 }
-export type PasswordIServerSpec = GeneralIServerSpec & PasswordAuthorization;
-export type OAuth2IServerSpec = GeneralIServerSpec & OAuth2Authorization;
-export type IServerSpec = PasswordIServerSpec | OAuth2IServerSpec;
 
 export interface ServerManagerAPI {
 	pickServer(
@@ -80,8 +62,16 @@ export interface ServerManagerAPI {
 
 	onDidChangePassword(
 	): vscode.Event<string>;
+}
 
-	getAuthorization(
-		authorization: Required<Authorization>
-	): string
+export class Authorization {
+	public resolved(): this is ResolvedAuthorization;
+	public resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
+}
+
+export class ResolvedAuthorization extends Authorization {
+	public get username(): string | undefined;
+	public get password(): string | undefined;
+	public get httpAuthorizationHeader(): string;
+	public get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,6 +62,11 @@ export interface ServerManagerAPI {
 
 	onDidChangePassword(
 	): vscode.Event<string>;
+
+	makeAuthorization(
+		username?: string,
+		password?: string,
+	): Authorization;
 }
 
 export class Authorization {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,6 +74,7 @@ export class Authorization {
 	public resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
 	public get username(): string;
 	public get password(): string | undefined;
+	public clone(): Authorization;
 }
 
 export class ResolvedAuthorization extends Authorization {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,6 +84,6 @@ export interface ServerManagerAPI {
 	): vscode.Event<string>;
 
 	getAuthorization(
-		authorization: Required<Authorization>
+		authorization: Required<Pick<Authorization, keyof Authorization>>
 	): String
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,8 +25,8 @@ export interface ISuperServerSpec {
 export interface IJSONServerSpec {
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
-	description?: string;
 	authorization: Authorization;
+	description?: string;
 }
 
 export interface IServerSpec extends IJSONServerSpec {
@@ -75,6 +75,8 @@ export class Authorization {
 	public get username(): string;
 	public get password(): string | undefined;
 	public clone(): Authorization;
+	public get httpAuthorizationHeader(): undefined | string;
+	public get credentials(): undefined | { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }
 
 export class ResolvedAuthorization extends Authorization {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ export interface IJSONServerSpec {
 	superServer?: ISuperServerSpec;
 	username?: string,
 	password?: string,
-	authorization: Authorization;
+	auth: Authorization;
 	description?: string;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,7 +73,7 @@ export interface ServerManagerAPI {
 
 export abstract class Authorization {
 	public abstract resolved(): this is ResolvedAuthorization;
-	public abstract resolve(params: { accessToken: string; username: string }): asserts this is ResolvedAuthorization;
+	public abstract resolve(params: { accessToken?: string; username?: string }): this is ResolvedAuthorization;
 	public abstract clear(): asserts this is Authorization;
 
 	public abstract get username(): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,6 +38,8 @@ interface PasswordIServerSpec extends GeneralIServerSpec {
 interface OAuth2IServerSpec extends GeneralIServerSpec {
 	authMethod: "oauth2";
 	username: "OAuth2User";
+	// The token is stored as password so that IServerSpec is backward-compatible (password is always a field although optional)
+	password?: string;
 	oauth2: {
 		authority: string;
 		clientId: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,15 +73,17 @@ export interface ServerManagerAPI {
 
 export class Authorization {
 	public resolved(): this is ResolvedAuthorization;
-	public resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
+	public resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization;
 	public get username(): string;
 	public get password(): string | undefined;
+	public get accessToken(): string | undefined;
 	public clone(): Authorization;
 	public get httpAuthorizationHeader(): undefined | string;
 	public get credentials(): undefined | { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }
 
 export class ResolvedAuthorization extends Authorization {
+	public get accessToken(): string;
 	public get httpAuthorizationHeader(): string;
 	public get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,8 +25,8 @@ export interface ISuperServerSpec {
 export interface IJSONServerSpec {
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
-	username?: string,
-	password?: string,
+	username?: string;
+	password?: string;
 	auth: Authorization;
 	description?: string;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,38 +23,30 @@ export interface ISuperServerSpec {
 }
 
 export interface PasswordAuthorization {
-	authMethod?: "password";
+	// The properties are present only if defined in the settings JSON.
+	//   Storage of `password` there is deprecated and strongly discouraged.
 	username?: string;
 	password?: string;
 }
 
 export interface OAuth2Authorization {
-	authMethod: "oauth2";
-	username?: string;
-	// The token is stored as password so that IServerSpec is backward-compatible (password is always a field although optional)
-	password?: string;
-	oauth2: {
-		authority: string;
-		clientId: string;
-	};
+	// The bearer_token is never present by getServerSpec for now.
+	bearer_token: string | undefined;
 }
 
 export type Authorization = PasswordAuthorization | OAuth2Authorization;
 
-interface GeneralIJSONServerSpec {
+export interface GeneralIJSONServerSpec {
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
 	description?: string;
 }
 
-export type PasswordIJSONServerSpec = GeneralIJSONServerSpec & PasswordAuthorization;
-export type OAuth2IJSONServerSpec = GeneralIJSONServerSpec & OAuth2Authorization;
-export type IJSONServerSpec = PasswordIJSONServerSpec | OAuth2IJSONServerSpec;
+export type IJSONServerSpec = GeneralIJSONServerSpec & Authorization;
 
-interface GeneralIServerSpec extends GeneralIJSONServerSpec {
+export interface GeneralIServerSpec extends GeneralIJSONServerSpec {
 	name: string;
 }
-
 export type PasswordIServerSpec = GeneralIServerSpec & PasswordAuthorization;
 export type OAuth2IServerSpec = GeneralIServerSpec & OAuth2Authorization;
 export type IServerSpec = PasswordIServerSpec | OAuth2IServerSpec;
@@ -90,6 +82,6 @@ export interface ServerManagerAPI {
 	): vscode.Event<string>;
 
 	getAuthorization(
-		authorization: Required<Pick<Authorization, keyof Authorization>>
-	): String
+		authorization: Required<Authorization>
+	): string
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,17 +22,29 @@ export interface ISuperServerSpec {
 	port: number;
 }
 
-export interface IJSONServerSpec {
+interface GeneralIServerSpec {
+	name: string;
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
-	username?: string;
-	password?: string;
 	description?: string;
 }
 
-export interface IServerSpec extends IJSONServerSpec {
-	name: string;
+interface PasswordIServerSpec extends GeneralIServerSpec {
+	authMethod?: "password";
+	username?: string;
+	password?: string;
 }
+
+interface OAuth2IServerSpec extends GeneralIServerSpec {
+	authMethod: "oauth2";
+	username: "OAuth2User";
+	oauth2: {
+		authority: string;
+		clientId: string;
+	};
+}
+
+export type IServerSpec = PasswordIServerSpec | OAuth2IServerSpec;
 
 export interface ServerManagerAPI {
 	pickServer(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,18 +71,19 @@ export interface ServerManagerAPI {
 	): Authorization;
 }
 
-export class Authorization {
-	public resolved(): this is ResolvedAuthorization;
-	public resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization;
-	public get username(): string;
-	public get password(): string | undefined;
-	public get accessToken(): string | undefined;
-	public clone(): Authorization;
-	public get httpAuthorizationHeader(): undefined | string;
-	public get credentials(): undefined | { auth?: { username: string; password: string }; headers?: Record<string, string> };
+export abstract class Authorization {
+	public abstract resolved(): this is ResolvedAuthorization;
+	public abstract resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization;
+	public abstract clear(): asserts this is Authorization;
+
+	public abstract get username(): string;
+	public abstract get password(): undefined | string;
+	public abstract get accessToken(): undefined | string;
+
+	public abstract clone(): Authorization;
 }
 
-export class ResolvedAuthorization extends Authorization {
+export abstract class ResolvedAuthorization extends Authorization {
 	public get accessToken(): string;
 	public get httpAuthorizationHeader(): string;
 	public get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,22 +22,22 @@ export interface ISuperServerSpec {
 	port: number;
 }
 
-interface GeneralIServerSpec {
+export interface GeneralIServerSpec {
 	name: string;
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
 	description?: string;
 }
 
-interface PasswordIServerSpec extends GeneralIServerSpec {
+export interface PasswordAuthorization {
 	authMethod?: "password";
 	username?: string;
 	password?: string;
 }
 
-interface OAuth2IServerSpec extends GeneralIServerSpec {
+export interface OAuth2Authorization {
 	authMethod: "oauth2";
-	username: "OAuth2User";
+	username?: string;
 	// The token is stored as password so that IServerSpec is backward-compatible (password is always a field although optional)
 	password?: string;
 	oauth2: {
@@ -45,6 +45,11 @@ interface OAuth2IServerSpec extends GeneralIServerSpec {
 		clientId: string;
 	};
 }
+
+export type Authorization = PasswordAuthorization | OAuth2Authorization;
+
+export type PasswordIServerSpec = GeneralIServerSpec & PasswordAuthorization;
+export type OAuth2IServerSpec = GeneralIServerSpec & OAuth2Authorization;
 
 export type IServerSpec = PasswordIServerSpec | OAuth2IServerSpec;
 
@@ -77,4 +82,8 @@ export interface ServerManagerAPI {
 
 	onDidChangePassword(
 	): vscode.Event<string>;
+
+	getAuthorization(
+		authorization: Required<Authorization>
+	): String
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,7 +73,7 @@ export interface ServerManagerAPI {
 
 export abstract class Authorization {
 	public abstract resolved(): this is ResolvedAuthorization;
-	public abstract resolve(accessToken: string, username: string): asserts this is ResolvedAuthorization;
+	public abstract resolve(params: { accessToken: string; username: string }): asserts this is ResolvedAuthorization;
 	public abstract clear(): asserts this is Authorization;
 
 	public abstract get username(): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,6 +25,8 @@ export interface ISuperServerSpec {
 export interface IJSONServerSpec {
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
+	username?: string,
+	password?: string,
 	authorization: Authorization;
 	description?: string;
 }
@@ -57,7 +59,7 @@ export interface ServerManagerAPI {
 	): Promise<IServerSpec | undefined>;
 
 	getAccount(
-		serverSpec: { name: string, username?: string }
+		serverSpec: Pick<IServerSpec, "name" | "username">,
 	): vscode.AuthenticationSessionAccountInformation | undefined;
 
 	onDidChangePassword(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,11 +72,11 @@ export interface ServerManagerAPI {
 export class Authorization {
 	public resolved(): this is ResolvedAuthorization;
 	public resolve(accessToken: string, username?: string): this is ResolvedAuthorization;
+	public get username(): string;
+	public get password(): string | undefined;
 }
 
 export class ResolvedAuthorization extends Authorization {
-	public get username(): string | undefined;
-	public get password(): string | undefined;
 	public get httpAuthorizationHeader(): string;
 	public get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,13 @@ export interface ISuperServerSpec {
 export interface IJSONServerSpec {
 	webServer: IWebServerSpec;
 	superServer?: ISuperServerSpec;
+	/**
+	 * @deprecated Use `auth.username` instead. Get credentials from the `auth` property.
+	 */
 	username?: string;
+	/**
+	 * @deprecated Use `auth.password` instead. Get credentials from the `auth` property.
+	 */
 	password?: string;
 	auth: Authorization;
 	description?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,10 +41,12 @@ export interface IServerSpec extends IJSONServerSpec {
 	name: string;
 }
 
+/** IServerSpec with `auth` guaranteed to be present. */
 export interface IServerSpecWithAuth extends IServerSpec {
 	auth: Authorization;
 }
 
+/** API to the Server Manager extension */
 export interface ServerManagerAPI {
 	pickServer(
 		scope?: vscode.ConfigurationScope,
@@ -75,15 +77,27 @@ export interface ServerManagerAPI {
 	onDidChangePassword(
 	): vscode.Event<string>;
 
+	/** Authorization to use when a server definition has no `auth` of its own.
+	 * This creates a Basic Auth that needs to be resolved with username and password.
+	 */
 	defaultAuth(): Authorization;
 }
 
+/**
+ * Represents a server's authentication state and how to apply it to a request.
+ * Implementations exist for basic auth (username/password) and OAuth2 (bearer token).
+ */
 export interface Authorization {
+	/** Whether enough credentials are present to authenticate a request. */
 	resolved(): this is ResolvedAuthorization;
+	/** Supplies missing credentials (e.g. from a prompt or token exchange); returns the new `resolved()` state. */
 	resolve(params: { accessToken?: string; username?: string }): this is ResolvedAuthorization;
+	/** Discards the resolved secret (password/token), reverting to an unresolved state. */
 	clear(): asserts this is Authorization;
+	/** Returns an independent copy carrying the same credentials. */
 	clone(): Authorization;
 
+	/** The IRIS username or "*OAuth2*" if authorized with OAuth2 */
 	get username(): string;
 	get password(): undefined | string;
 
@@ -92,6 +106,7 @@ export interface Authorization {
 	get credentials(): undefined | { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }
 
+/** Narrowed `Authorization` known to hold usable credentials, per `resolved()`. */
 export interface ResolvedAuthorization extends Authorization {
 	get accessToken(): string;
 	get httpAuthorizationHeader(): string;
@@ -121,6 +136,7 @@ export interface ServerForUri {
 	namespace: string;
 }
 
+/** API to the VSCode ObjectScript extension */
 export interface VSCodeObjectScriptAPI {
 	serverForUri: (uri: vscode.Uri) => ServerForUri | undefined;
 	asyncServerForUri: (uri: vscode.Uri) => Promise<ServerForUri | undefined>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,27 +70,24 @@ export interface ServerManagerAPI {
 
 	onDidChangePassword(
 	): vscode.Event<string>;
-
-	makeAuthorization(
-		username?: string,
-		password?: string,
-	): Authorization;
 }
 
-export abstract class Authorization {
-	public abstract resolved(): this is ResolvedAuthorization;
-	public abstract resolve(params: { accessToken?: string; username?: string }): this is ResolvedAuthorization;
-	public abstract clear(): asserts this is Authorization;
+export interface Authorization {
+	resolved(): this is ResolvedAuthorization;
+	resolve(params: { accessToken?: string; username?: string }): this is ResolvedAuthorization;
+	clear(): asserts this is Authorization;
+	clone(): Authorization;
 
-	public abstract get username(): string;
-	public abstract get password(): undefined | string;
-	public abstract get accessToken(): undefined | string;
+	get username(): string;
+	get password(): undefined | string;
 
-	public abstract clone(): Authorization;
+	get accessToken(): undefined | string;
+	get httpAuthorizationHeader(): undefined | string;
+	get credentials(): undefined | { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }
 
-export abstract class ResolvedAuthorization extends Authorization {
-	public get accessToken(): string;
-	public get httpAuthorizationHeader(): string;
-	public get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
+export interface ResolvedAuthorization extends Authorization {
+	get accessToken(): string;
+	get httpAuthorizationHeader(): string;
+	get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,12 +33,16 @@ export interface IJSONServerSpec {
 	 * @deprecated Use `auth.password` instead. Get credentials from the `auth` property.
 	 */
 	password?: string;
-	auth: Authorization;
+	auth?: Authorization;
 	description?: string;
 }
 
 export interface IServerSpec extends IJSONServerSpec {
 	name: string;
+}
+
+export interface IServerSpecWithAuth extends IServerSpec {
+	auth: Authorization;
 }
 
 export interface ServerManagerAPI {
@@ -62,7 +66,7 @@ export interface ServerManagerAPI {
 		scope?: vscode.ConfigurationScope,
 		flushCredentialCache?: boolean,
 		options?: { hideFromRecents?: boolean, /* Obsolete */ noCredentials?: boolean },
-	): Promise<IServerSpec | undefined>;
+	): Promise<IServerSpecWithAuth | undefined>;
 
 	getAccount(
 		serverSpec: Pick<IServerSpec, "name" | "username">,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,6 +74,8 @@ export interface ServerManagerAPI {
 
 	onDidChangePassword(
 	): vscode.Event<string>;
+
+	defaultAuth(): Authorization;
 }
 
 export interface Authorization {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,3 +97,26 @@ export interface ResolvedAuthorization extends Authorization {
 	get httpAuthorizationHeader(): string;
 	get credentials(): { auth?: { username: string; password: string }; headers?: Record<string, string> };
 }
+
+export interface ServerForUri {
+	serverName: string;
+	active: boolean;
+	apiVersion: number;
+	serverVersion: string;
+	scheme: "http" | "https";
+	https?: boolean;
+	host: string;
+	port: number;
+	superserverPort?: number;
+	pathPrefix: string;
+	auth: Authorization;
+	namespace: string;
+}
+
+export interface VSCodeObjectScriptAPI {
+	serverForUri: (uri: vscode.Uri) => ServerForUri;
+	asyncServerForUri: (uri: vscode.Uri) => Promise<ServerForUri>;
+	serverDocumentUriForUri(uri: vscode.Uri): vscode.Uri;
+	onDidChangeConnection(): vscode.Event<void>;
+	getUriForDocument(document: string): vscode.Uri;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,13 +109,21 @@ export interface ServerForUri {
 	port: number;
 	superserverPort?: number;
 	pathPrefix: string;
-	auth: Authorization;
+	auth?: Authorization;
+	/**
+	 * @deprecated Use `auth.username` instead. Get credentials from the `auth` property.
+	 */
+	username?: string;
+	/**
+	 * @deprecated Use `auth.password` instead. Get credentials from the `auth` property.
+	 */
+	password?: string;
 	namespace: string;
 }
 
 export interface VSCodeObjectScriptAPI {
-	serverForUri: (uri: vscode.Uri) => ServerForUri;
-	asyncServerForUri: (uri: vscode.Uri) => Promise<ServerForUri>;
+	serverForUri: (uri: vscode.Uri) => ServerForUri | undefined;
+	asyncServerForUri: (uri: vscode.Uri) => Promise<ServerForUri | undefined>;
 	serverDocumentUriForUri(uri: vscode.Uri): vscode.Uri;
 	onDidChangeConnection(): vscode.Event<void>;
 	getUriForDocument(document: string): vscode.Uri;

--- a/types/index.js
+++ b/types/index.js
@@ -1,4 +1,6 @@
 module.exports = {
 	EXTENSION_ID: 'intersystems-community.servermanager',
-	AUTHENTICATION_PROVIDER: 'intersystems-server-credentials'
+	AUTHENTICATION_PROVIDER: 'intersystems-server-credentials',
+	Authorization: class { }
 };
+

--- a/types/index.js
+++ b/types/index.js
@@ -1,6 +1,5 @@
 module.exports = {
 	EXTENSION_ID: 'intersystems-community.servermanager',
 	AUTHENTICATION_PROVIDER: 'intersystems-server-credentials',
-	Authorization: class { }
 };
 

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intersystems-community/intersystems-servermanager",
-  "version": "3.10.3-beta.2",
+  "version": "3.14.0",
   "description": "InterSystems Server Manager VS Code extension API interfaces and constants",
   "types": "index.d.ts",
   "main": "index.js",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intersystems-community/intersystems-servermanager",
-  "version": "3.10.3-beta.1",
+  "version": "3.10.3-beta.2",
   "description": "InterSystems Server Manager VS Code extension API interfaces and constants",
   "types": "index.d.ts",
   "main": "index.js",
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/intersystems-community/intersystems-servermanager.git",
+    "url": "git+https://github.com/intersystems-community/intersystems-servermanager.git",
     "directory": "types"
   },
   "bugs": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intersystems-community/intersystems-servermanager",
-  "version": "3.10.2",
+  "version": "3.10.3-beta.1",
   "description": "InterSystems Server Manager VS Code extension API interfaces and constants",
   "types": "index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
This update enable OAuth2 support for this extension.

- New Authorization class architecture: Refactored authentication handling with PasswordAuthorization and OAuth2Authorization implementations
- OAuth2 configuration: Added oauth2 field to server settings with authority, clientId, and scopes properties
- Server setup wizard: Updated add server flow to prompt for auth method (password vs OAuth2) with guided OAuth2 configuration
- Type definitions: Enhanced [types/index.d.ts](vscode-webview://05f7uv2oklc8gqe9sv0te0n147cbk7i968ru1hohkg4k7o6iin84/types/index.d.ts) with Authorization interface, deprecated username/password fields in favor of auth property
- API updates: getServerSpec() now returns IServerSpecWithAuth with resolved credentials via the Authorization class
- Backward compatibility: Legacy username/password credentials continue to work; deprecated fields marked in types