### PR TITLE
Replace `any` types with proper TypeScript type definitions

### DIFF
--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -33,7 +33,15 @@ export async function getServerSpec(
 			// Activating it here would cause a deadlock because the activate method of the ObjectScript extension itself calls our getServerSpec API
 			return undefined;
 		}
-		let serverForUri: any;
+		let serverForUri: {
+			serverName: string;
+			scheme: string;
+			host: string;
+			port: number;
+			pathPrefix: string;
+			username: string;
+			password?: string;
+		};
 		if (objectScriptExtension.exports.asyncServerForUri) {
 			serverForUri = await objectScriptExtension.exports.asyncServerForUri(folder.uri);
 		} else {

--- a/src/commands/importFromRegistry.ts
+++ b/src/commands/importFromRegistry.ts
@@ -2,11 +2,11 @@ import * as vscode from "vscode";
 import { ServerManagerAuthenticationProvider } from "../authenticationProvider";
 
 // To avoid overhead querying the registry, cache responses (each time the command is run)
-const regQueryCache = new Map<string, any>();
+const regQueryCache = new Map<string, { data?: string }>();
 
 export async function importFromRegistry(secretStorage: vscode.SecretStorage, scope?: vscode.ConfigurationScope) {
 	const config = vscode.workspace.getConfiguration("intersystems", scope);
-	const serverDefinitions: any = config.get("servers");
+	const serverDefinitions: ServerDefinitions = config.get("servers") ?? {};
 
 	const newServerNames = new Array<string>();
 	const serversMissingUsernames = new Array<string>();
@@ -147,7 +147,7 @@ async function loadRegistryData(
 	return overwriteCount;
 }
 
-async function promptForUsernames(serverDefinitions: any, serversMissingUsernames: string[]): Promise<boolean> {
+async function promptForUsernames(serverDefinitions: ServerDefinitions, serversMissingUsernames: string[]): Promise<boolean> {
 	if (serversMissingUsernames.length) {
 		let serverName = serversMissingUsernames.splice(0, 1)[0];
 		let username = await vscode.window.showInputBox({
@@ -163,7 +163,7 @@ async function promptForUsernames(serverDefinitions: any, serversMissingUsername
 			// If unspecified, actually set to undefined to leave it empty in serverDefinitions
 			username = undefined;
 		}
-		serverDefinitions[serverName].username = username;
+		serverDefinitions[serverName]!.username = username;
 		if (serversMissingUsernames.length > 0) {
 			const reuseMessage = (username === undefined) ? `Prompt for username at connect time for all of them` : `Use '${username}' as the username for all of them`;
 			const items = [
@@ -204,7 +204,13 @@ async function promptForUsernames(serverDefinitions: any, serversMissingUsername
 	return true;
 }
 
-async function promptForPasswords(secretStorage: vscode.SecretStorage, serverDefinitions: any, newServerNames: string[]): Promise<void> {
+export interface ServerDefinition {
+	username?: string;
+}
+
+export type ServerDefinitions = Record<string, ServerDefinition>;
+
+async function promptForPasswords(secretStorage: vscode.SecretStorage, serverDefinitions: ServerDefinitions, newServerNames: string[]): Promise<void> {
 	let reusePassword;
 	let password: string | undefined = "";
 	const promptServerNames = new Array();
@@ -253,7 +259,7 @@ async function promptForPasswords(secretStorage: vscode.SecretStorage, serverDef
 		}
 
 		if ((password !== "") && (password !== undefined)) {
-			const username = serverDefinitions[serverName].username;
+			const username = serverDefinitions[serverName]?.username!;
 			const sessionId = ServerManagerAuthenticationProvider.sessionId(serverName, username);
 			const credentialKey = ServerManagerAuthenticationProvider.credentialKey(sessionId);
 			await secretStorage.store(credentialKey, password).then(() => {

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IServerName, IServerSpec } from "@intersystems-community/intersystems-servermanager";
+import { IServerName, IServerSpec, ServerManagerAPI } from "@intersystems-community/intersystems-servermanager";
 import { addServer } from "./api/addServer";
 import { getPortalUri } from "./api/getPortalUri";
 import { getServerNames } from "./api/getServerNames";
@@ -24,7 +24,7 @@ export function getAccountFromParts(serverName: string, userName?: string): vsco
  * Handle all activation requirements that are shared by `extension.ts` and `web-extension.ts`.
  * Returns our exported API.
  */
-export function commonActivate(context: vscode.ExtensionContext, view: ServerManagerView): any {
+export function commonActivate(context: vscode.ExtensionContext, view: ServerManagerView): ServerManagerAPI {
 	const _onDidChangePassword = new vscode.EventEmitter<string>();
 
 	// Other parts of this extension will use this to persist state
@@ -199,8 +199,8 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 		vscode.commands.registerCommand(`${extensionId}.editSettings`, (server?: ServerTreeItem) => {
 			// Attempt to open the correct JSON file
 			server = server instanceof ServerTreeItem ? server : undefined;
-			const scope: vscode.ConfigurationScope = server?.params?.serverSummary?.scope;
-			const servers = vscode.workspace.getConfiguration("intersystems", scope).inspect<{ [key: string]: any }>("servers");
+			const scope = server?.params?.serverSummary?.scope;
+			const servers = vscode.workspace.getConfiguration("intersystems", scope).inspect("servers");
 			const openJSONArg = { revealSetting: { key: "intersystems.servers" } };
 			const revealServer = (): void => {
 				// Find the start of the server's settings block

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
 	// Do our best to log out of all sessions
 
-	const promises: Promise<any>[] = [];
+	const promises: Promise<void>[] = [];
 	for (const serverSession of serverSessions) {
 		promises.push(logout(serverSession[1].serverName));
 	}

--- a/src/ui/serverManagerView.ts
+++ b/src/ui/serverManagerView.ts
@@ -211,6 +211,15 @@ class SMNodeProvider implements vscode.TreeDataProvider<SMTreeItem> {
 	}
 }
 
+export interface ServerParams {
+	sorted?: boolean;
+	serverSummary?: IServerName;
+	serverName?: string;
+	serverSpec?: IServerSpec;
+	serverApiVersion?: number;
+	ns?: string;
+}
+
 interface ISMItem {
 	label: string;
 	id: string;
@@ -221,7 +230,7 @@ interface ISMItem {
 	codiconName?: string;
 	// tslint:disable-next-line: ban-types
 	getChildren?: Function;
-	params?: any;
+	params?: ServerParams;
 }
 
 // tslint:disable-next-line: max-classes-per-file
@@ -230,7 +239,7 @@ export class SMTreeItem extends vscode.TreeItem {
 	public readonly parent: SMTreeItem | undefined;
 	// tslint:disable-next-line: ban-types
 	private readonly _getChildren?: Function;
-	public readonly params?: any;
+	public readonly params?: ServerParams;
 
 	constructor(item: ISMItem) {
 		const collapsibleState = item.getChildren
@@ -259,7 +268,7 @@ export class SMTreeItem extends vscode.TreeItem {
 	}
 }
 
-function allServers(treeItem: SMTreeItem, params?: any): ServerTreeItem[] {
+function allServers(treeItem: SMTreeItem, params?: ServerParams): ServerTreeItem[] {
 	const children: ServerTreeItem[] = [];
 	// Add children for servers defined at the user or workspace level
 	const wsServerNames = getServerNames(undefined);
@@ -280,7 +289,7 @@ function allServers(treeItem: SMTreeItem, params?: any): ServerTreeItem[] {
 	return children;
 }
 
-async function currentServers(element: SMTreeItem, params?: any): Promise<ServerTreeItem[]> {
+async function currentServers(element: SMTreeItem, params?: ServerParams): Promise<ServerTreeItem[]> {
 	const children = new Map<string, ServerTreeItem>();
 	const dockerLocalPorts = new Map<number, string>();
 
@@ -342,7 +351,7 @@ async function currentServers(element: SMTreeItem, params?: any): Promise<Server
 	return Array.from(children.values()).sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
 }
 
-function favoriteServers(element: SMTreeItem, params?: any): ServerTreeItem[] {
+function favoriteServers(element: SMTreeItem, params?: ServerParams): ServerTreeItem[] {
 	const children: ServerTreeItem[] = [];
 
 	favoritesMap.forEach((_, name) => {
@@ -355,7 +364,7 @@ function favoriteServers(element: SMTreeItem, params?: any): ServerTreeItem[] {
 	return children.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
 }
 
-function recentServers(element: SMTreeItem, params?: any): ServerTreeItem[] {
+function recentServers(element: SMTreeItem, params?: ServerParams): ServerTreeItem[] {
 	const children: ServerTreeItem[] = [];
 
 	recentsArray.map((name) => {
@@ -410,7 +419,7 @@ export class ServerTreeItem extends SMTreeItem {
  * @param params (unused)
  * @returns feature folders of a server.
  */
-async function serverFeatures(element: ServerTreeItem, params?: any): Promise<FeatureTreeItem[] | undefined> {
+async function serverFeatures(element: ServerTreeItem, params?: ServerParams): Promise<FeatureTreeItem[] | undefined> {
 	const children: FeatureTreeItem[] = [];
 
 	if (params?.serverSummary) {
@@ -504,7 +513,7 @@ export class NamespacesTreeItem extends FeatureTreeItem {
  * @param params (unused)
  * @returns namespaces of a server.
  */
-async function serverNamespaces(element: ServerTreeItem, params?: any): Promise<NamespaceTreeItem[] | undefined> {
+async function serverNamespaces(element: ServerTreeItem, params?: ServerParams): Promise<NamespaceTreeItem[] | undefined> {
 	const children: NamespaceTreeItem[] = [];
 
 	if (params?.serverName) {
@@ -570,10 +579,10 @@ export class NamespaceTreeItem extends SMTreeItem {
  * @param params (unused)
  * @returns feature folders of a namespace.
  */
-async function namespaceFeatures(element: NamespaceTreeItem, params?: any): Promise<FeatureTreeItem[] | undefined> {
+async function namespaceFeatures(element: NamespaceTreeItem, params?: ServerParams): Promise<FeatureTreeItem[] | undefined> {
 	return [
-		new ProjectsTreeItem({ parent: element, id: element.name, label: element.name }, params.serverName, params.serverSpec, params.serverApiVersion),
-		new WebAppsTreeItem({ parent: element, id: element.name, label: element.name }, params.serverName, params.serverSpec, params.serverApiVersion)
+		new ProjectsTreeItem({ parent: element, id: element.name, label: element.name }, params?.serverName, params?.serverSpec, params?.serverApiVersion),
+		new WebAppsTreeItem({ parent: element, id: element.name, label: element.name }, params?.serverName, params?.serverSpec, params?.serverApiVersion)
 	];
 }
 
@@ -581,9 +590,9 @@ export class ProjectsTreeItem extends FeatureTreeItem {
 	public readonly name: string;
 	constructor(
 		element: ISMItem,
-		serverName: string,
-		serverSpec: IServerSpec,
-		serverApiVersion: number
+		serverName?: string,
+		serverSpec?: IServerSpec,
+		serverApiVersion: number = 0
 	) {
 		const parentFolderId = element.parent?.id || '';
 		super({
@@ -607,7 +616,7 @@ export class ProjectsTreeItem extends FeatureTreeItem {
  * @param params { serverName }
  * @returns projects in a server namespace.
  */
-async function namespaceProjects(element: ProjectsTreeItem, params?: any): Promise<ProjectTreeItem[] | undefined> {
+async function namespaceProjects(element: ProjectsTreeItem, params?: ServerParams): Promise<ProjectTreeItem[] | undefined> {
 	const children: ProjectTreeItem[] = [];
 
 	if (params?.serverName && params.ns) {
@@ -635,7 +644,7 @@ async function namespaceProjects(element: ProjectsTreeItem, params?: any): Promi
 				return undefined;
 			}
 			response.data.result.content.map((project) => {
-				children.push(new ProjectTreeItem({ parent: element, label: name, id: name }, project.Name, project.Description, params.serverApiVersion));
+				children.push(new ProjectTreeItem({ parent: element, label: name, id: name }, project.Name, project.Description, params.serverApiVersion!));
 			});
 		}
 	}
@@ -669,9 +678,9 @@ export class WebAppsTreeItem extends FeatureTreeItem {
 	public readonly name: string;
 	constructor(
 		element: ISMItem,
-		serverName: string,
-		serverSpec: IServerSpec,
-		serverApiVersion: number
+		serverName: string | undefined,
+		serverSpec: IServerSpec | undefined,
+		serverApiVersion: number = 0
 	) {
 		const parentFolderId = element.parent?.id || '';
 		super({
@@ -695,7 +704,7 @@ export class WebAppsTreeItem extends FeatureTreeItem {
  * @param params { serverName }
  * @returns web applications in a server namespace.
  */
-async function namespaceWebApps(element: ProjectsTreeItem, params?: any): Promise<WebAppTreeItem[] | undefined> {
+async function namespaceWebApps(element: ProjectsTreeItem, params?: ServerParams & { serverApiVersion: number }): Promise<WebAppTreeItem[] | undefined> {
 	const children: ProjectTreeItem[] = [];
 
 	if (params?.serverName && params.ns) {
@@ -715,7 +724,7 @@ async function namespaceWebApps(element: ProjectsTreeItem, params?: any): Promis
 				vscode.window.showErrorMessage(response.data.status.summary);
 				return undefined;
 			}
-			response.data.result.content.map((webapp: any) => {
+			response.data.result.content.map((webapp: { name: string, default: boolean }) => {
 				children.push(new WebAppTreeItem({ parent: element, label: name, id: name }, webapp.name, webapp.default, params.serverApiVersion));
 			});
 		}

--- a/src/web-extension.ts
+++ b/src/web-extension.ts
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
 	// Do our best to log out of all sessions
 
-	const promises: Promise<any>[] = [];
+	const promises: Promise<void>[] = [];
 	for (const serverSession of serverSessions) {
 		promises.push(logout(serverSession[1].serverName));
 	}


### PR DESCRIPTION
- Define ServerDefinition and ServerDefinitions types
- Define ServerParams interface for tree view components
- Type serverForUri object with explicit properties
- Add non-null assertions where server existence is guaranteed
- Replace generic Promise<any>[] with the actual concrete type Promise<void>[]