### PR TITLE
No longer clear authorization before returning from getServerSpec

### DIFF
--- a/src/api/getServerSpec.ts
+++ b/src/api/getServerSpec.ts
@@ -50,27 +50,28 @@ export async function getServerSpec(
 			auth: auth ?? new BasicAuthorization(username, password),
 			description: `Server for workspace folder "${name}"`,
 		};
+	} else {
+		// Found a setting
+		const { username, password, oauth2, ...spec } = setting;
+		spec.name = name;
+		spec.description = spec.description || "";
+		spec.webServer.scheme = spec.webServer.scheme || "http";
+		spec.webServer.port = spec.webServer.port || (spec.webServer.scheme === "https" ? 443 : 80);
+		spec.webServer.pathPrefix = spec.webServer.pathPrefix || "";
+		if (spec.superServer) {
+			// Fall back to default if appropriate
+			spec.superServer.host = spec.superServer.host || spec.webServer.host;
+		}
+		const auth = oauth2
+			? new OAuth2Authorization(oauth2)
+			: new BasicAuthorization(username, password);
+		return {
+			...spec,
+			auth,
+			username: auth.username,
+			password: auth.password,
+		};
 	}
-
-	const { username, password, oauth2, ...spec } = setting;
-	spec.name = name;
-	spec.description = spec.description || "";
-	spec.webServer.scheme = spec.webServer.scheme || "http";
-	spec.webServer.port = spec.webServer.port || (spec.webServer.scheme === "https" ? 443 : 80);
-	spec.webServer.pathPrefix = spec.webServer.pathPrefix || "";
-	if (spec.superServer) {
-		// Fall back to default if appropriate
-		spec.superServer.host = spec.superServer.host || spec.webServer.host;
-	}
-	const auth = oauth2
-		? new OAuth2Authorization(oauth2)
-		: new BasicAuthorization(username, password);
-	return {
-		...spec,
-		auth,
-		username: auth.username,
-		password: auth.password,
-	};
 }
 
 /**

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -510,12 +510,9 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			if (spec === undefined) {
 				return undefined;
 			}
-
 			if (!options?.hideFromRecents) {
 				await view.addToRecents(name);
 			}
-
-			spec.auth = spec.auth.clone();
 			return spec;
 		},
 

--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -516,8 +516,6 @@ export function commonActivate(context: vscode.ExtensionContext, view: ServerMan
 			}
 
 			spec.auth = spec.auth.clone();
-			spec.auth.clear() as void;
-
 			return spec;
 		},
 


### PR DESCRIPTION
This PR fixes #348.

The ServerSpec returned by getServerSpec() in src/commonActivate.ts is constructed by getServerSpec() in src/api/getServerSpec.ts. I verified that every code path in the latter function returns a resolved Authorization object only when:

- The authorization has already been resolved by the VS Code ObjectScript extension, or
- The password is readily available in settings.json.

Because of this, it is safe for getServerSpec() to return the Authorization object without clearing its access token.

This PR removes the access token clearing logic and makes a small refactoring to src/api/getServerSpec.ts to clarify the control flow.